### PR TITLE
Improvement: Add database check constraints for data integrity

### DIFF
--- a/src/main/java/com/realestate/backend/service/AgentProfileService.java
+++ b/src/main/java/com/realestate/backend/service/AgentProfileService.java
@@ -2,9 +2,7 @@ package com.realestate.backend.service;
 
 import com.realestate.backend.dto.user.UserProfileDtos.*;
 import com.realestate.backend.entity.profile.AgentProfile;
-import com.realestate.backend.exception.ConflictException;
-import com.realestate.backend.exception.ForbiddenException;
-import com.realestate.backend.exception.ResourceNotFoundException;
+import com.realestate.backend.exception.*;
 import com.realestate.backend.multitenancy.TenantContext;
 import com.realestate.backend.repository.AgentProfileRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Slf4j
@@ -21,72 +20,129 @@ public class AgentProfileService {
 
     private final AgentProfileRepository agentProfileRepo;
 
-    // ── Merr profilin tim ─────────────────────────────────────
+    // ── Vlera të lejuara ──────────────────────────────────────────────────────
+    private static final int    MAX_PHONE_LENGTH         = 30;
+    private static final int    MAX_LICENSE_LENGTH       = 100;
+    private static final int    MAX_SPECIALIZATION_LEN   = 100;
+    private static final int    MAX_EXPERIENCE_YEARS     = 60;
+    private static final BigDecimal MAX_RATING           = BigDecimal.valueOf(5);
+    private static final BigDecimal MIN_RATING           = BigDecimal.ZERO;
+
+    // ── Merr profilin tim ────────────────────────────────────────────────────
     @Transactional(readOnly = true)
     public AgentProfileResponse getMyProfile() {
         Long userId = TenantContext.getUserId();
         return agentProfileRepo.findByUserId(userId)
                 .map(this::toResponse)
-                .orElseThrow(() -> new ResourceNotFoundException("Profili i agjentit nuk u gjet"));
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Profili i agjentit nuk u gjet. Krijo profilin me PUT /api/users/agents/me"));
     }
 
-    // ── Merr profilin sipas userId ────────────────────────────
+    // ── Merr profilin sipas userId ────────────────────────────────────────────
     @Transactional(readOnly = true)
     public AgentProfileResponse getByUserId(Long userId) {
         return agentProfileRepo.findByUserId(userId)
                 .map(this::toResponse)
-                .orElseThrow(() -> new ResourceNotFoundException("Profili i agjentit nuk u gjet për user: " + userId));
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Profili i agjentit nuk u gjet për user: " + userId));
     }
 
-    // ── Lista e të gjithë agjentëve ───────────────────────────
+    // ── Lista e të gjithë agjentëve (sipas vlerësimit) ────────────────────────
     @Transactional(readOnly = true)
     public List<AgentProfileResponse> getAllAgents() {
         return agentProfileRepo.findAllByOrderByRatingDesc()
                 .stream().map(this::toResponse).toList();
     }
 
-    // ── Krijo ose ndrysho profilin tim ────────────────────────
+    // ── Krijo ose ndrysho profilin tim ───────────────────────────────────────
     @Transactional
     public AgentProfileResponse upsertMyProfile(AgentProfileRequest req) {
         assertIsAgent();
         Long userId = TenantContext.getUserId();
 
+        // ── Validime ─────────────────────────────────────────────────────────
+        validateAgentProfileRequest(req);
+
         AgentProfile profile = agentProfileRepo.findByUserId(userId)
                 .orElseGet(() -> AgentProfile.builder().userId(userId).build());
 
-        if (req.phone()           != null) profile.setPhone(req.phone());
-        if (req.license()         != null) profile.setLicense(req.license());
-        if (req.bio()             != null) profile.setBio(req.bio());
-        if (req.experienceYears() != null) profile.setExperienceYears(req.experienceYears());
-        if (req.specialization()  != null) profile.setSpecialization(req.specialization());
-        if (req.photoUrl()        != null) profile.setPhotoUrl(req.photoUrl());
+        applyAgentProfileFields(profile, req);
 
         AgentProfile saved = agentProfileRepo.save(profile);
         log.info("AgentProfile u ruajt për userId={}", userId);
         return toResponse(saved);
     }
 
-    // ── ADMIN: ndrysho profilin e çdo agjenti ─────────────────
+    // ── ADMIN: ndrysho profilin e çdo agjenti ────────────────────────────────
     @Transactional
     public AgentProfileResponse updateProfile(Long userId, AgentProfileRequest req) {
         if (!TenantContext.hasRole("ADMIN")) {
             throw new ForbiddenException("Vetëm ADMIN mund të ndryshojë profil tjetër");
         }
 
+        // ── Validime ─────────────────────────────────────────────────────────
+        validateAgentProfileRequest(req);
+
         AgentProfile profile = agentProfileRepo.findByUserId(userId)
-                .orElseThrow(() -> new ResourceNotFoundException("Profili nuk u gjet: " + userId));
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Profili nuk u gjet për user: " + userId));
 
-        if (req.phone()           != null) profile.setPhone(req.phone());
-        if (req.license()         != null) profile.setLicense(req.license());
-        if (req.bio()             != null) profile.setBio(req.bio());
-        if (req.experienceYears() != null) profile.setExperienceYears(req.experienceYears());
-        if (req.specialization()  != null) profile.setSpecialization(req.specialization());
-        if (req.photoUrl()        != null) profile.setPhotoUrl(req.photoUrl());
+        applyAgentProfileFields(profile, req);
 
-        return toResponse(agentProfileRepo.save(profile));
+        AgentProfile saved = agentProfileRepo.save(profile);
+        log.info("AgentProfile i userId={} u ndryshua nga ADMIN", userId);
+        return toResponse(saved);
     }
 
-    // ── Helpers ───────────────────────────────────────────────
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private void validateAgentProfileRequest(AgentProfileRequest req) {
+        if (req.phone() != null) {
+            String cleaned = req.phone().replaceAll("[\\s\\-()]", "");
+            if (!cleaned.matches("^\\+?[0-9]{6,15}$")) {
+                throw new BadRequestException(
+                        "Numri i telefonit është i pavlefshëm. Format i pranueshëm: +3834XXXXXXX ose 04XXXXXXX");
+            }
+            if (req.phone().length() > MAX_PHONE_LENGTH) {
+                throw new BadRequestException(
+                        "Numri i telefonit nuk mund të jetë më i gjatë se " + MAX_PHONE_LENGTH + " karaktere");
+            }
+        }
+        if (req.license() != null && req.license().length() > MAX_LICENSE_LENGTH) {
+            throw new BadRequestException(
+                    "Licença nuk mund të jetë më e gjatë se " + MAX_LICENSE_LENGTH + " karaktere");
+        }
+        if (req.experienceYears() != null) {
+            if (req.experienceYears() < 0) {
+                throw new BadRequestException("Vitet e përvojës nuk mund të jenë negative");
+            }
+            if (req.experienceYears() > MAX_EXPERIENCE_YEARS) {
+                throw new BadRequestException(
+                        "Vitet e përvojës nuk mund të jenë më shumë se " + MAX_EXPERIENCE_YEARS);
+            }
+        }
+        if (req.specialization() != null && req.specialization().length() > MAX_SPECIALIZATION_LEN) {
+            throw new BadRequestException(
+                    "Specializimi nuk mund të jetë më i gjatë se " + MAX_SPECIALIZATION_LEN + " karaktere");
+        }
+        if (req.photoUrl() != null && !req.photoUrl().isBlank()) {
+            if (!req.photoUrl().matches("^https?://.*")) {
+                throw new BadRequestException("URL e fotos duhet të fillojë me http:// ose https://");
+            }
+            if (req.photoUrl().length() > 500) {
+                throw new BadRequestException("URL e fotos nuk mund të jetë më e gjatë se 500 karaktere");
+            }
+        }
+    }
+
+    private void applyAgentProfileFields(AgentProfile profile, AgentProfileRequest req) {
+        if (req.phone()           != null) profile.setPhone(req.phone().trim());
+        if (req.license()         != null) profile.setLicense(req.license().trim());
+        if (req.bio()             != null) profile.setBio(req.bio().trim());
+        if (req.experienceYears() != null) profile.setExperienceYears(req.experienceYears());
+        if (req.specialization()  != null) profile.setSpecialization(req.specialization().trim());
+        if (req.photoUrl()        != null) profile.setPhotoUrl(req.photoUrl().trim());
+    }
 
     private void assertIsAgent() {
         if (!TenantContext.hasRole("ADMIN", "AGENT")) {

--- a/src/main/java/com/realestate/backend/service/AgentProfileService.java
+++ b/src/main/java/com/realestate/backend/service/AgentProfileService.java
@@ -20,7 +20,7 @@ public class AgentProfileService {
 
     private final AgentProfileRepository agentProfileRepo;
 
-    // ── Vlera të lejuara ──────────────────────────────────────────────────────
+    // Vlera të lejuara
     private static final int    MAX_PHONE_LENGTH         = 30;
     private static final int    MAX_LICENSE_LENGTH       = 100;
     private static final int    MAX_SPECIALIZATION_LEN   = 100;
@@ -28,7 +28,7 @@ public class AgentProfileService {
     private static final BigDecimal MAX_RATING           = BigDecimal.valueOf(5);
     private static final BigDecimal MIN_RATING           = BigDecimal.ZERO;
 
-    // ── Merr profilin tim ────────────────────────────────────────────────────
+    // Merr profilin tim
     @Transactional(readOnly = true)
     public AgentProfileResponse getMyProfile() {
         Long userId = TenantContext.getUserId();
@@ -38,7 +38,7 @@ public class AgentProfileService {
                         "Profili i agjentit nuk u gjet. Krijo profilin me PUT /api/users/agents/me"));
     }
 
-    // ── Merr profilin sipas userId ────────────────────────────────────────────
+    // Merr profilin sipas userId
     @Transactional(readOnly = true)
     public AgentProfileResponse getByUserId(Long userId) {
         return agentProfileRepo.findByUserId(userId)
@@ -47,20 +47,20 @@ public class AgentProfileService {
                         "Profili i agjentit nuk u gjet për user: " + userId));
     }
 
-    // ── Lista e të gjithë agjentëve (sipas vlerësimit) ────────────────────────
+    // Lista e të gjithë agjentëve (sipas vlerësimit)
     @Transactional(readOnly = true)
     public List<AgentProfileResponse> getAllAgents() {
         return agentProfileRepo.findAllByOrderByRatingDesc()
                 .stream().map(this::toResponse).toList();
     }
 
-    // ── Krijo ose ndrysho profilin tim ───────────────────────────────────────
+    // Krijo ose ndrysho profilin tim
     @Transactional
     public AgentProfileResponse upsertMyProfile(AgentProfileRequest req) {
         assertIsAgent();
         Long userId = TenantContext.getUserId();
 
-        // ── Validime ─────────────────────────────────────────────────────────
+        // Validime
         validateAgentProfileRequest(req);
 
         AgentProfile profile = agentProfileRepo.findByUserId(userId)
@@ -73,14 +73,14 @@ public class AgentProfileService {
         return toResponse(saved);
     }
 
-    // ── ADMIN: ndrysho profilin e çdo agjenti ────────────────────────────────
+    // ADMIN: ndrysho profilin e çdo agjenti
     @Transactional
     public AgentProfileResponse updateProfile(Long userId, AgentProfileRequest req) {
         if (!TenantContext.hasRole("ADMIN")) {
             throw new ForbiddenException("Vetëm ADMIN mund të ndryshojë profil tjetër");
         }
 
-        // ── Validime ─────────────────────────────────────────────────────────
+        // Validime
         validateAgentProfileRequest(req);
 
         AgentProfile profile = agentProfileRepo.findByUserId(userId)
@@ -94,7 +94,7 @@ public class AgentProfileService {
         return toResponse(saved);
     }
 
-    // ── Helpers ───────────────────────────────────────────────────────────────
+    // Helpers
 
     private void validateAgentProfileRequest(AgentProfileRequest req) {
         if (req.phone() != null) {

--- a/src/main/java/com/realestate/backend/service/ClientProfileService.java
+++ b/src/main/java/com/realestate/backend/service/ClientProfileService.java
@@ -2,14 +2,16 @@ package com.realestate.backend.service;
 
 import com.realestate.backend.dto.user.UserProfileDtos.*;
 import com.realestate.backend.entity.profile.ClientProfile;
-import com.realestate.backend.exception.ForbiddenException;
-import com.realestate.backend.exception.ResourceNotFoundException;
+import com.realestate.backend.exception.*;
 import com.realestate.backend.multitenancy.TenantContext;
 import com.realestate.backend.repository.ClientProfileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -18,48 +20,122 @@ public class ClientProfileService {
 
     private final ClientProfileRepository clientProfileRepo;
 
-    // ── Merr profilin tim ─────────────────────────────────────
+    // ── Vlera të lejuara — reflektojnë CHECK constraint në DB ────────────────
+    // preferred_contact VARCHAR(20) CHECK (preferred_contact IN ('EMAIL','PHONE','WHATSAPP'))
+    private static final Set<String> VALID_CONTACT_METHODS = Set.of("EMAIL", "PHONE", "WHATSAPP");
+
+    // ── Merr profilin tim ────────────────────────────────────────────────────
     @Transactional(readOnly = true)
     public ClientProfileResponse getMyProfile() {
         Long userId = TenantContext.getUserId();
         return clientProfileRepo.findByUserId(userId)
                 .map(this::toResponse)
-                .orElseThrow(() -> new ResourceNotFoundException("Profili i klientit nuk u gjet"));
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Profili i klientit nuk u gjet. Krijo profilin me PUT /api/users/clients/me"));
     }
 
-    // ── ADMIN/AGENT: merr profilin e klientit ─────────────────
+    // ── ADMIN/AGENT: merr profilin e klientit ────────────────────────────────
     @Transactional(readOnly = true)
     public ClientProfileResponse getByUserId(Long userId) {
         if (!TenantContext.hasRole("ADMIN", "AGENT")) {
-            throw new ForbiddenException("Nuk keni leje");
+            throw new ForbiddenException("Nuk keni leje të shikoni profilin e klientit");
         }
         return clientProfileRepo.findByUserId(userId)
                 .map(this::toResponse)
-                .orElseThrow(() -> new ResourceNotFoundException("Profili nuk u gjet: " + userId));
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Profili i klientit nuk u gjet për user: " + userId));
     }
 
-    // ── Krijo ose ndrysho profilin tim ────────────────────────
+    // ── Krijo ose ndrysho profilin tim ───────────────────────────────────────
     @Transactional
     public ClientProfileResponse upsertMyProfile(ClientProfileRequest req) {
         Long userId = TenantContext.getUserId();
 
+        // ── Validime ─────────────────────────────────────────────────────────
+        validateClientProfileRequest(req);
+
         ClientProfile profile = clientProfileRepo.findByUserId(userId)
                 .orElseGet(() -> ClientProfile.builder().userId(userId).build());
 
-        if (req.phone()            != null) profile.setPhone(req.phone());
-        if (req.preferredContact() != null) profile.setPreferredContact(req.preferredContact());
-        if (req.budgetMin()        != null) profile.setBudgetMin(req.budgetMin());
-        if (req.budgetMax()        != null) profile.setBudgetMax(req.budgetMax());
-        if (req.preferredType()    != null) profile.setPreferredType(req.preferredType());
-        if (req.preferredCity()    != null) profile.setPreferredCity(req.preferredCity());
-        if (req.photoUrl()         != null) profile.setPhotoUrl(req.photoUrl());
+        applyClientProfileFields(profile, req);
 
         ClientProfile saved = clientProfileRepo.save(profile);
         log.info("ClientProfile u ruajt për userId={}", userId);
         return toResponse(saved);
     }
 
-    // ── Mapper ────────────────────────────────────────────────
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private void validateClientProfileRequest(ClientProfileRequest req) {
+
+        // preferred_contact CHECK constraint: EMAIL | PHONE | WHATSAPP
+        if (req.preferredContact() != null
+                && !VALID_CONTACT_METHODS.contains(req.preferredContact().toUpperCase())) {
+            throw new BadRequestException(
+                    "Metoda e kontaktit e pavlefshme: '" + req.preferredContact()
+                            + "'. Vlerat e lejuara: " + VALID_CONTACT_METHODS);
+        }
+
+        // budget_min dhe budget_max — nuk mund të jenë negative
+        if (req.budgetMin() != null && req.budgetMin().compareTo(BigDecimal.ZERO) < 0) {
+            throw new BadRequestException("Buxheti minimal nuk mund të jetë negativ");
+        }
+        if (req.budgetMax() != null && req.budgetMax().compareTo(BigDecimal.ZERO) < 0) {
+            throw new BadRequestException("Buxheti maksimal nuk mund të jetë negativ");
+        }
+
+        // budget_min nuk mund të jetë më i madh se budget_max
+        if (req.budgetMin() != null && req.budgetMax() != null
+                && req.budgetMin().compareTo(req.budgetMax()) > 0) {
+            throw new BadRequestException(
+                    "Buxheti minimal (" + req.budgetMin()
+                            + ") nuk mund të jetë më i madh se buxheti maksimal (" + req.budgetMax() + ")");
+        }
+
+        // phone — format bazik
+        if (req.phone() != null && !req.phone().isBlank()) {
+            String cleaned = req.phone().replaceAll("[\\s\\-()]", "");
+            if (!cleaned.matches("^\\+?[0-9]{6,15}$")) {
+                throw new BadRequestException(
+                        "Numri i telefonit është i pavlefshëm. Format i pranueshëm: +3834XXXXXXX");
+            }
+            if (req.phone().length() > 30) {
+                throw new BadRequestException("Numri i telefonit nuk mund të jetë më i gjatë se 30 karaktere");
+            }
+        }
+
+        // preferred_type — VARCHAR(50)
+        if (req.preferredType() != null && req.preferredType().length() > 50) {
+            throw new BadRequestException("Tipi i preferuar nuk mund të jetë më i gjatë se 50 karaktere");
+        }
+
+        // preferred_city — VARCHAR(100)
+        if (req.preferredCity() != null && req.preferredCity().length() > 100) {
+            throw new BadRequestException("Qyteti i preferuar nuk mund të jetë më i gjatë se 100 karaktere");
+        }
+
+        // photo_url — VARCHAR(500) + format HTTP
+        if (req.photoUrl() != null && !req.photoUrl().isBlank()) {
+            if (!req.photoUrl().matches("^https?://.*")) {
+                throw new BadRequestException("URL e fotos duhet të fillojë me http:// ose https://");
+            }
+            if (req.photoUrl().length() > 500) {
+                throw new BadRequestException("URL e fotos nuk mund të jetë më e gjatë se 500 karaktere");
+            }
+        }
+    }
+
+    private void applyClientProfileFields(ClientProfile profile, ClientProfileRequest req) {
+        if (req.phone()            != null) profile.setPhone(req.phone().trim());
+        if (req.preferredContact() != null) profile.setPreferredContact(req.preferredContact().toUpperCase());
+        if (req.budgetMin()        != null) profile.setBudgetMin(req.budgetMin());
+        if (req.budgetMax()        != null) profile.setBudgetMax(req.budgetMax());
+        if (req.preferredType()    != null) profile.setPreferredType(req.preferredType().trim());
+        if (req.preferredCity()    != null) profile.setPreferredCity(req.preferredCity().trim());
+        if (req.photoUrl()         != null) profile.setPhotoUrl(req.photoUrl().trim());
+    }
+
+    // ── Mapper ────────────────────────────────────────────────────────────────
 
     private ClientProfileResponse toResponse(ClientProfile p) {
         return new ClientProfileResponse(

--- a/src/main/java/com/realestate/backend/service/ClientProfileService.java
+++ b/src/main/java/com/realestate/backend/service/ClientProfileService.java
@@ -20,11 +20,11 @@ public class ClientProfileService {
 
     private final ClientProfileRepository clientProfileRepo;
 
-    // ── Vlera të lejuara — reflektojnë CHECK constraint në DB ────────────────
+    // Vlera të lejuara — reflektojnë CHECK constraint në DB
     // preferred_contact VARCHAR(20) CHECK (preferred_contact IN ('EMAIL','PHONE','WHATSAPP'))
     private static final Set<String> VALID_CONTACT_METHODS = Set.of("EMAIL", "PHONE", "WHATSAPP");
 
-    // ── Merr profilin tim ────────────────────────────────────────────────────
+    // Merr profilin tim
     @Transactional(readOnly = true)
     public ClientProfileResponse getMyProfile() {
         Long userId = TenantContext.getUserId();
@@ -34,7 +34,7 @@ public class ClientProfileService {
                         "Profili i klientit nuk u gjet. Krijo profilin me PUT /api/users/clients/me"));
     }
 
-    // ── ADMIN/AGENT: merr profilin e klientit ────────────────────────────────
+    // ADMIN/AGENT: merr profilin e klientit
     @Transactional(readOnly = true)
     public ClientProfileResponse getByUserId(Long userId) {
         if (!TenantContext.hasRole("ADMIN", "AGENT")) {
@@ -46,12 +46,12 @@ public class ClientProfileService {
                         "Profili i klientit nuk u gjet për user: " + userId));
     }
 
-    // ── Krijo ose ndrysho profilin tim ───────────────────────────────────────
+    // Krijo ose ndrysho profilin tim
     @Transactional
     public ClientProfileResponse upsertMyProfile(ClientProfileRequest req) {
         Long userId = TenantContext.getUserId();
 
-        // ── Validime ─────────────────────────────────────────────────────────
+        // Validime
         validateClientProfileRequest(req);
 
         ClientProfile profile = clientProfileRepo.findByUserId(userId)
@@ -64,7 +64,7 @@ public class ClientProfileService {
         return toResponse(saved);
     }
 
-    // ── Helpers ───────────────────────────────────────────────────────────────
+    // Helpers
 
     private void validateClientProfileRequest(ClientProfileRequest req) {
 
@@ -135,7 +135,7 @@ public class ClientProfileService {
         if (req.photoUrl()         != null) profile.setPhotoUrl(req.photoUrl().trim());
     }
 
-    // ── Mapper ────────────────────────────────────────────────────────────────
+    // Mapper
 
     private ClientProfileResponse toResponse(ClientProfile p) {
         return new ClientProfileResponse(

--- a/src/main/java/com/realestate/backend/service/LeadService.java
+++ b/src/main/java/com/realestate/backend/service/LeadService.java
@@ -1,11 +1,12 @@
 package com.realestate.backend.service;
 
 import com.realestate.backend.dto.lead.LeadDtos.*;
+import com.realestate.backend.entity.enums.LeadSource;
 import com.realestate.backend.entity.enums.LeadStatus;
+import com.realestate.backend.entity.enums.LeadType;
 import com.realestate.backend.entity.lead.PropertyLeadRequest;
 import com.realestate.backend.entity.property.Property;
-import com.realestate.backend.exception.ForbiddenException;
-import com.realestate.backend.exception.ResourceNotFoundException;
+import com.realestate.backend.exception.*;
 import com.realestate.backend.multitenancy.TenantContext;
 import com.realestate.backend.repository.LeadRequestRepository;
 import com.realestate.backend.repository.PropertyRepository;
@@ -15,6 +16,8 @@ import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 
 @Slf4j
@@ -25,22 +28,21 @@ public class LeadService {
     private final LeadRequestRepository leadRepo;
     private final PropertyRepository    propertyRepo;
 
-    // ── Të gjitha leads (ADMIN/AGENT) ────────────────────────
+    // ── Të gjitha leads (ADMIN/AGENT) ────────────────────────────────────────
     @Transactional(readOnly = true)
     public Page<LeadResponse> getAll(Pageable pageable) {
         assertIsAdminOrAgent();
-        return leadRepo.findByStatusOrderByCreatedAtDesc(LeadStatus.NEW, pageable)
-                .map(this::toResponse);
+        return leadRepo.findByStatusOrderByCreatedAtDesc(LeadStatus.NEW, pageable).map(this::toResponse);
     }
 
-    // ── Leads sipas statusit ───────────────────────────────────
+    // ── Leads sipas statusit ──────────────────────────────────────────────────
     @Transactional(readOnly = true)
     public Page<LeadResponse> getByStatus(LeadStatus status, Pageable pageable) {
         assertIsAdminOrAgent();
         return leadRepo.findByStatusOrderByCreatedAtDesc(status, pageable).map(this::toResponse);
     }
 
-    // ── Leads të agjentit ─────────────────────────────────────
+    // ── Leads të agjentit ────────────────────────────────────────────────────
     @Transactional(readOnly = true)
     public Page<LeadResponse> getMyLeadsAsAgent(Pageable pageable) {
         assertIsAdminOrAgent();
@@ -48,27 +50,27 @@ public class LeadService {
                 .map(this::toResponse);
     }
 
-    // ── Leads të klientit ─────────────────────────────────────
+    // ── Leads të klientit ────────────────────────────────────────────────────
     @Transactional(readOnly = true)
     public Page<LeadResponse> getMyLeadsAsClient(Pageable pageable) {
         return leadRepo.findByClientIdOrderByCreatedAtDesc(TenantContext.getUserId(), pageable)
                 .map(this::toResponse);
     }
 
-    // ── Leads të paassinjuara ─────────────────────────────────
+    // ── Leads të paassinjuara (ADMIN) ─────────────────────────────────────────
     @Transactional(readOnly = true)
     public List<LeadResponse> getUnassigned() {
         assertIsAdmin();
         return leadRepo.findUnassigned().stream().map(this::toResponse).toList();
     }
 
-    // ── Merr sipas ID ─────────────────────────────────────────
+    // ── Merr sipas ID ────────────────────────────────────────────────────────
     @Transactional(readOnly = true)
     public LeadResponse getById(Long id) {
         return toResponse(findLead(id));
     }
 
-    // ── Leads sipas pronës ────────────────────────────────────
+    // ── Leads sipas pronës ───────────────────────────────────────────────────
     @Transactional(readOnly = true)
     public List<LeadResponse> getByProperty(Long propertyId) {
         assertIsAdminOrAgent();
@@ -76,15 +78,38 @@ public class LeadService {
                 .stream().map(this::toResponse).toList();
     }
 
-    // ── Krijo lead ────────────────────────────────────────────
+    // ── Krijo lead ───────────────────────────────────────────────────────────
     @Transactional
     public LeadResponse create(LeadCreateRequest req) {
+
+        // ── Validime ─────────────────────────────────────────────────────────
+        if (req.type() == null) {
+            throw new BadRequestException("Tipi i kërkesës është i detyrueshëm. "
+                    + "Vlerat e lejuara: SELL, BUY, RENT, VALUATION");
+        }
+        if (req.budget() != null && req.budget().compareTo(BigDecimal.ZERO) < 0) {
+            throw new BadRequestException("Buxheti nuk mund të jetë negativ");
+        }
+        if (req.preferredDate() != null && req.preferredDate().isBefore(LocalDate.now())) {
+            throw new BadRequestException("Data e preferuar nuk mund të jetë në të kaluarën");
+        }
+        // source ka default WEBSITE — nuk ka nevojë për validim shtesë
+        // sepse tipi LeadSource e garanton vlerën e vlefshme
+
         Long clientId = TenantContext.getUserId();
 
         Property property = null;
         if (req.propertyId() != null) {
             property = propertyRepo.findByIdAndDeletedAtIsNull(req.propertyId())
-                    .orElseThrow(() -> new ResourceNotFoundException("Prona nuk u gjet: " + req.propertyId()));
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "Prona nuk u gjet: " + req.propertyId()));
+        }
+
+        // BUY/RENT pa pronë është OK (klient kërkon pronë)
+        // SELL/VALUATION pa pronë — paralajmërim në log (jo error)
+        if ((req.type() == LeadType.SELL || req.type() == LeadType.VALUATION)
+                && property == null) {
+            log.warn("Lead tipi {} u krijua pa pronë — clientId={}", req.type(), clientId);
         }
 
         PropertyLeadRequest lead = PropertyLeadRequest.builder()
@@ -94,7 +119,7 @@ public class LeadService {
                 .message(req.message())
                 .budget(req.budget())
                 .preferredDate(req.preferredDate())
-                .source(req.source() != null ? req.source() : com.realestate.backend.entity.enums.LeadSource.WEBSITE)
+                .source(req.source() != null ? req.source() : LeadSource.WEBSITE)
                 .status(LeadStatus.NEW)
                 .build();
 
@@ -103,27 +128,55 @@ public class LeadService {
         return toResponse(saved);
     }
 
-    // ── Asinjono agjent ───────────────────────────────────────
+    // ── Asinjono agjent (ADMIN) ───────────────────────────────────────────────
     @Transactional
     public LeadResponse assignAgent(Long id, LeadAssignRequest req) {
         assertIsAdmin();
-        findLead(id);
+
+        PropertyLeadRequest lead = findLead(id);
+
+        // ── Validime ─────────────────────────────────────────────────────────
+        if (lead.getStatus() == LeadStatus.DONE || lead.getStatus() == LeadStatus.REJECTED) {
+            throw new InvalidStateException("Leadi me status '"
+                    + lead.getStatus() + "' nuk mund të asinohet");
+        }
+        if (req.agentId() == null) {
+            throw new BadRequestException("agent_id është i detyrueshëm");
+        }
+
         leadRepo.assignAgent(id, req.agentId());
         log.info("Lead id={} u asinjua tek agjenti id={}", id, req.agentId());
         return toResponse(findLead(id));
     }
 
-    // ── Ndrysho statusin ──────────────────────────────────────
+    // ── Ndrysho statusin ──────────────────────────────────────────────────────
     @Transactional
     public LeadResponse updateStatus(Long id, LeadStatusRequest req) {
         assertIsAdminOrAgent();
-        findLead(id);
+
+        PropertyLeadRequest lead = findLead(id);
+
+        // ── Validime — tranzicionet e lejuara ────────────────────────────────
+        // NEW        → IN_PROGRESS, REJECTED
+        // IN_PROGRESS → DONE, REJECTED
+        // DONE       → (final, nuk ndryshon)
+        // REJECTED   → (final, nuk ndryshon)
+        if (lead.getStatus() == LeadStatus.DONE || lead.getStatus() == LeadStatus.REJECTED) {
+            throw new InvalidStateException("Leadi me status '"
+                    + lead.getStatus() + "' është final dhe nuk mund të ndryshohet");
+        }
+        if (req.status() == LeadStatus.NEW) {
+            throw new BadRequestException("Leadi nuk mund të kthehet në statusin NEW");
+        }
+        // Agjent nuk mund të vendosë REJECTED pa qenë ADMIN — opsionale
+        // (e lëmë në mënyrën aktuale — të dy rolet mund të refuzojnë)
+
         leadRepo.updateStatus(id, req.status());
-        log.info("Lead id={} statusi u ndryshua në {}", id, req.status());
+        log.info("Lead id={} statusi u ndryshua nga {} në {}", id, lead.getStatus(), req.status());
         return toResponse(findLead(id));
     }
 
-    // ── Helpers ───────────────────────────────────────────────
+    // ── Helpers ───────────────────────────────────────────────────────────────
 
     private PropertyLeadRequest findLead(Long id) {
         return leadRepo.findById(id)
@@ -142,7 +195,7 @@ public class LeadService {
         }
     }
 
-    // ── Mapper ────────────────────────────────────────────────
+    // ── Mapper ────────────────────────────────────────────────────────────────
 
     private LeadResponse toResponse(PropertyLeadRequest l) {
         return new LeadResponse(

--- a/src/main/java/com/realestate/backend/service/LeadService.java
+++ b/src/main/java/com/realestate/backend/service/LeadService.java
@@ -28,21 +28,21 @@ public class LeadService {
     private final LeadRequestRepository leadRepo;
     private final PropertyRepository    propertyRepo;
 
-    // ── Të gjitha leads (ADMIN/AGENT) ────────────────────────────────────────
+    // Të gjitha leads (ADMIN/AGENT)
     @Transactional(readOnly = true)
     public Page<LeadResponse> getAll(Pageable pageable) {
         assertIsAdminOrAgent();
         return leadRepo.findByStatusOrderByCreatedAtDesc(LeadStatus.NEW, pageable).map(this::toResponse);
     }
 
-    // ── Leads sipas statusit ──────────────────────────────────────────────────
+    // Leads sipas statusit
     @Transactional(readOnly = true)
     public Page<LeadResponse> getByStatus(LeadStatus status, Pageable pageable) {
         assertIsAdminOrAgent();
         return leadRepo.findByStatusOrderByCreatedAtDesc(status, pageable).map(this::toResponse);
     }
 
-    // ── Leads të agjentit ────────────────────────────────────────────────────
+    // Leads të agjentit
     @Transactional(readOnly = true)
     public Page<LeadResponse> getMyLeadsAsAgent(Pageable pageable) {
         assertIsAdminOrAgent();
@@ -50,27 +50,27 @@ public class LeadService {
                 .map(this::toResponse);
     }
 
-    // ── Leads të klientit ────────────────────────────────────────────────────
+    // Leads të klientit
     @Transactional(readOnly = true)
     public Page<LeadResponse> getMyLeadsAsClient(Pageable pageable) {
         return leadRepo.findByClientIdOrderByCreatedAtDesc(TenantContext.getUserId(), pageable)
                 .map(this::toResponse);
     }
 
-    // ── Leads të paassinjuara (ADMIN) ─────────────────────────────────────────
+    // Leads të paassinjuara (ADMIN)
     @Transactional(readOnly = true)
     public List<LeadResponse> getUnassigned() {
         assertIsAdmin();
         return leadRepo.findUnassigned().stream().map(this::toResponse).toList();
     }
 
-    // ── Merr sipas ID ────────────────────────────────────────────────────────
+    // Merr sipas ID
     @Transactional(readOnly = true)
     public LeadResponse getById(Long id) {
         return toResponse(findLead(id));
     }
 
-    // ── Leads sipas pronës ───────────────────────────────────────────────────
+    // Leads sipas pronës
     @Transactional(readOnly = true)
     public List<LeadResponse> getByProperty(Long propertyId) {
         assertIsAdminOrAgent();
@@ -78,11 +78,11 @@ public class LeadService {
                 .stream().map(this::toResponse).toList();
     }
 
-    // ── Krijo lead ───────────────────────────────────────────────────────────
+    // Krijo lead
     @Transactional
     public LeadResponse create(LeadCreateRequest req) {
 
-        // ── Validime ─────────────────────────────────────────────────────────
+        // Validime
         if (req.type() == null) {
             throw new BadRequestException("Tipi i kërkesës është i detyrueshëm. "
                     + "Vlerat e lejuara: SELL, BUY, RENT, VALUATION");
@@ -128,14 +128,14 @@ public class LeadService {
         return toResponse(saved);
     }
 
-    // ── Asinjono agjent (ADMIN) ───────────────────────────────────────────────
+    // Asinjono agjent (ADMIN)
     @Transactional
     public LeadResponse assignAgent(Long id, LeadAssignRequest req) {
         assertIsAdmin();
 
         PropertyLeadRequest lead = findLead(id);
 
-        // ── Validime ─────────────────────────────────────────────────────────
+        // Validime
         if (lead.getStatus() == LeadStatus.DONE || lead.getStatus() == LeadStatus.REJECTED) {
             throw new InvalidStateException("Leadi me status '"
                     + lead.getStatus() + "' nuk mund të asinohet");
@@ -149,7 +149,7 @@ public class LeadService {
         return toResponse(findLead(id));
     }
 
-    // ── Ndrysho statusin ──────────────────────────────────────────────────────
+    // Ndrysho statusin
     @Transactional
     public LeadResponse updateStatus(Long id, LeadStatusRequest req) {
         assertIsAdminOrAgent();
@@ -176,7 +176,7 @@ public class LeadService {
         return toResponse(findLead(id));
     }
 
-    // ── Helpers ───────────────────────────────────────────────────────────────
+    // Helpers
 
     private PropertyLeadRequest findLead(Long id) {
         return leadRepo.findById(id)
@@ -195,7 +195,7 @@ public class LeadService {
         }
     }
 
-    // ── Mapper ────────────────────────────────────────────────────────────────
+    // Mapper
 
     private LeadResponse toResponse(PropertyLeadRequest l) {
         return new LeadResponse(

--- a/src/main/java/com/realestate/backend/service/SaleService.java
+++ b/src/main/java/com/realestate/backend/service/SaleService.java
@@ -6,14 +6,9 @@ import com.realestate.backend.entity.property.Property;
 import com.realestate.backend.entity.sale.SaleContract;
 import com.realestate.backend.entity.sale.SaleListing;
 import com.realestate.backend.entity.sale.SalePayment;
-import com.realestate.backend.exception.ConflictException;
-import com.realestate.backend.exception.ForbiddenException;
-import com.realestate.backend.exception.ResourceNotFoundException;
+import com.realestate.backend.exception.*;
 import com.realestate.backend.multitenancy.TenantContext;
-import com.realestate.backend.repository.PropertyRepository;
-import com.realestate.backend.repository.SaleContractRepository;
-import com.realestate.backend.repository.SaleListingRepository;
-import com.realestate.backend.repository.SalePaymentRepository;
+import com.realestate.backend.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
@@ -23,18 +18,27 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class SaleService {
 
-    private final SaleListingRepository   listingRepo;
-    private final SaleContractRepository  contractRepo;
-    private final SalePaymentRepository   paymentRepo;
-    private final PropertyRepository      propertyRepo;
+    private final SaleListingRepository  listingRepo;
+    private final SaleContractRepository contractRepo;
+    private final SalePaymentRepository  paymentRepo;
+    private final PropertyRepository     propertyRepo;
 
-    // ══════════════════ SALE LISTINGS ══════════════════════════
+    // ── Vlerat e lejuara (reflektojnë CHECK constraints në DB) ──────────────
+    private static final Set<String> VALID_CURRENCIES     = Set.of("EUR", "USD", "ALL", "GBP", "CHF");
+    private static final Set<String> VALID_CONTRACT_STATUS = Set.of("PENDING", "COMPLETED", "CANCELLED");
+    private static final Set<String> VALID_PAYMENT_TYPES  = Set.of("DEPOSIT", "INSTALLMENT", "FULL", "COMMISSION");
+    private static final Set<String> VALID_PAYMENT_STATUS = Set.of("PENDING", "PAID", "FAILED", "REFUNDED");
+    private static final Set<String> VALID_PAYMENT_METHODS =
+            Set.of("BANK_TRANSFER", "CASH", "CARD", "CHECK", "ONLINE");
+
+    // ══════════════════ SALE LISTINGS ═══════════════════════════════════════
 
     @Transactional(readOnly = true)
     public Page<SaleListingResponse> getAllListings(Pageable pageable) {
@@ -61,6 +65,15 @@ public class SaleService {
     public SaleListingResponse createListing(SaleListingCreateRequest req) {
         assertIsAdminOrAgent();
 
+        // ── Validime ────────────────────────────────────────────────────────
+        if (req.price() == null || req.price().compareTo(BigDecimal.ZERO) < 0) {
+            throw new BadRequestException("Çmimi duhet të jetë 0 ose më i madh");
+        }
+        if (req.currency() != null && !VALID_CURRENCIES.contains(req.currency().toUpperCase())) {
+            throw new BadRequestException("Monedha e pavlefshme: " + req.currency()
+                    + ". Vlerat e lejuara: " + VALID_CURRENCIES);
+        }
+
         Property property = propertyRepo.findByIdAndDeletedAtIsNull(req.propertyId())
                 .orElseThrow(() -> new ResourceNotFoundException("Prona nuk u gjet: " + req.propertyId()));
 
@@ -68,7 +81,7 @@ public class SaleService {
                 .property(property)
                 .agentId(TenantContext.getUserId())
                 .price(req.price())
-                .currency(req.currency() != null ? req.currency() : "EUR")
+                .currency(req.currency() != null ? req.currency().toUpperCase() : "EUR")
                 .negotiable(req.negotiable() != null ? req.negotiable() : true)
                 .description(req.description())
                 .highlights(req.highlights())
@@ -86,8 +99,16 @@ public class SaleService {
         SaleListing listing = findActiveListing(id);
         assertCanModifyListing(listing);
 
+        // ── Validime ────────────────────────────────────────────────────────
+        if (req.price() != null && req.price().compareTo(BigDecimal.ZERO) < 0) {
+            throw new BadRequestException("Çmimi nuk mund të jetë negativ");
+        }
+        if (req.currency() != null && !VALID_CURRENCIES.contains(req.currency().toUpperCase())) {
+            throw new BadRequestException("Monedha e pavlefshme: " + req.currency());
+        }
+
         if (req.price()       != null) listing.setPrice(req.price());
-        if (req.currency()    != null) listing.setCurrency(req.currency());
+        if (req.currency()    != null) listing.setCurrency(req.currency().toUpperCase());
         if (req.negotiable()  != null) listing.setNegotiable(req.negotiable());
         if (req.description() != null) listing.setDescription(req.description());
         if (req.highlights()  != null) listing.setHighlights(req.highlights());
@@ -104,7 +125,7 @@ public class SaleService {
         log.info("SaleListing id={} u fshi (soft delete)", id);
     }
 
-    // ══════════════════ SALE CONTRACTS ══════════════════════════
+    // ══════════════════ SALE CONTRACTS ═══════════════════════════════════════
 
     @Transactional(readOnly = true)
     public Page<SaleContractResponse> getAllContracts(Pageable pageable) {
@@ -139,8 +160,23 @@ public class SaleService {
     public SaleContractResponse createContract(SaleContractCreateRequest req) {
         assertIsAdminOrAgent();
 
+        // ── Validime ────────────────────────────────────────────────────────
+        if (req.salePrice() == null || req.salePrice().compareTo(BigDecimal.ZERO) < 0) {
+            throw new BadRequestException("Çmimi i shitjes duhet të jetë 0 ose më i madh");
+        }
+        if (req.currency() != null && !VALID_CURRENCIES.contains(req.currency().toUpperCase())) {
+            throw new BadRequestException("Monedha e pavlefshme: " + req.currency());
+        }
+        if (req.contractDate() != null && req.handoverDate() != null
+                && req.handoverDate().isBefore(req.contractDate())) {
+            throw new BadRequestException("Data e dorëzimit nuk mund të jetë para datës së kontratës");
+        }
+
+        // Kontratë aktive ekziston tashmë?
         contractRepo.findByProperty_IdAndStatus(req.propertyId(), "PENDING")
-                .ifPresent(c -> { throw new ConflictException("Prona ka tashmë kontratë PENDING: " + c.getId()); });
+                .ifPresent(c -> {
+                    throw new ConflictException("Prona ka tashmë kontratë PENDING: " + c.getId());
+                });
 
         Property property = propertyRepo.findByIdAndDeletedAtIsNull(req.propertyId())
                 .orElseThrow(() -> new ResourceNotFoundException("Prona nuk u gjet: " + req.propertyId()));
@@ -156,7 +192,7 @@ public class SaleService {
                 .buyerId(req.buyerId())
                 .agentId(TenantContext.getUserId())
                 .salePrice(req.salePrice())
-                .currency(req.currency() != null ? req.currency() : "EUR")
+                .currency(req.currency() != null ? req.currency().toUpperCase() : "EUR")
                 .contractDate(req.contractDate())
                 .handoverDate(req.handoverDate())
                 .contractFileUrl(req.contractFileUrl())
@@ -164,7 +200,8 @@ public class SaleService {
                 .build();
 
         SaleContract saved = contractRepo.save(contract);
-        log.info("SaleContract u krijua: id={}, property={}, buyer={}", saved.getId(), req.propertyId(), req.buyerId());
+        log.info("SaleContract u krijua: id={}, property={}, buyer={}",
+                saved.getId(), req.propertyId(), req.buyerId());
         return toContractResponse(saved);
     }
 
@@ -173,12 +210,25 @@ public class SaleService {
         assertIsAdminOrAgent();
         SaleContract contract = findContract(id);
 
+        // ── Validime ────────────────────────────────────────────────────────
         if ("COMPLETED".equals(contract.getStatus()) || "CANCELLED".equals(contract.getStatus())) {
             throw new ConflictException("Kontratat e mbyllura nuk mund të ndryshohen");
         }
+        if (req.salePrice() != null && req.salePrice().compareTo(BigDecimal.ZERO) < 0) {
+            throw new BadRequestException("Çmimi i shitjes nuk mund të jetë negativ");
+        }
+        if (req.currency() != null && !VALID_CURRENCIES.contains(req.currency().toUpperCase())) {
+            throw new BadRequestException("Monedha e pavlefshme: " + req.currency());
+        }
+
+        LocalDate newContractDate = req.contractDate() != null ? req.contractDate() : contract.getContractDate();
+        LocalDate newHandoverDate = req.handoverDate() != null ? req.handoverDate() : contract.getHandoverDate();
+        if (newContractDate != null && newHandoverDate != null && newHandoverDate.isBefore(newContractDate)) {
+            throw new BadRequestException("Data e dorëzimit nuk mund të jetë para datës së kontratës");
+        }
 
         if (req.salePrice()       != null) contract.setSalePrice(req.salePrice());
-        if (req.currency()        != null) contract.setCurrency(req.currency());
+        if (req.currency()        != null) contract.setCurrency(req.currency().toUpperCase());
         if (req.contractDate()    != null) contract.setContractDate(req.contractDate());
         if (req.handoverDate()    != null) contract.setHandoverDate(req.handoverDate());
         if (req.contractFileUrl() != null) contract.setContractFileUrl(req.contractFileUrl());
@@ -189,17 +239,34 @@ public class SaleService {
     @Transactional
     public SaleContractResponse updateContractStatus(Long id, SaleContractStatusRequest req) {
         assertIsAdminOrAgent();
-        findContract(id);
+        SaleContract contract = findContract(id);
+
+        // ── Validime ────────────────────────────────────────────────────────
+        if (!VALID_CONTRACT_STATUS.contains(req.status())) {
+            throw new BadRequestException("Statusi i pavlefshëm: " + req.status()
+                    + ". Vlerat e lejuara: " + VALID_CONTRACT_STATUS);
+        }
+        // Tranzicionet e lejuara: PENDING → COMPLETED | CANCELLED
+        // Nuk mund të kthehesh nga COMPLETED ose CANCELLED
+        if ("COMPLETED".equals(contract.getStatus()) || "CANCELLED".equals(contract.getStatus())) {
+            throw new ConflictException("Kontrata me status '"
+                    + contract.getStatus() + "' nuk mund të ndryshohet");
+        }
+        if ("PENDING".equals(req.status())) {
+            throw new BadRequestException("Kontrata nuk mund të kthehet në PENDING");
+        }
+
         contractRepo.updateStatus(id, req.status());
         log.info("SaleContract id={} statusi u ndryshua në {}", id, req.status());
         return toContractResponse(findContract(id));
     }
 
-    // ══════════════════ SALE PAYMENTS ═══════════════════════════
+    // ══════════════════ SALE PAYMENTS ════════════════════════════════════════
 
     @Transactional(readOnly = true)
     public List<SalePaymentResponse> getPaymentsByContract(Long contractId) {
         assertIsAdminOrAgent();
+        findContract(contractId); // kontrollo ekzistencën
         return paymentRepo.findByContract_IdOrderByCreatedAtAsc(contractId)
                 .stream().map(this::toPaymentResponse).toList();
     }
@@ -207,6 +274,7 @@ public class SaleService {
     @Transactional(readOnly = true)
     public SalePaymentSummaryResponse getPaymentSummary(Long contractId) {
         assertIsAdminOrAgent();
+        findContract(contractId);
         List<SalePaymentResponse> payments = paymentRepo
                 .findByContract_IdOrderByCreatedAtAsc(contractId)
                 .stream().map(this::toPaymentResponse).toList();
@@ -217,41 +285,77 @@ public class SaleService {
     @Transactional
     public SalePaymentResponse createPayment(SalePaymentCreateRequest req) {
         assertIsAdminOrAgent();
+
+        // ── Validime ────────────────────────────────────────────────────────
+        if (req.amount() == null || req.amount().compareTo(BigDecimal.ZERO) < 0) {
+            throw new BadRequestException("Shuma duhet të jetë 0 ose më e madhe");
+        }
+        if (req.currency() != null && !VALID_CURRENCIES.contains(req.currency().toUpperCase())) {
+            throw new BadRequestException("Monedha e pavlefshme: " + req.currency());
+        }
+        if (req.paymentType() != null && !VALID_PAYMENT_TYPES.contains(req.paymentType().toUpperCase())) {
+            throw new BadRequestException("Tipi i pagesës i pavlefshëm: " + req.paymentType()
+                    + ". Vlerat e lejuara: " + VALID_PAYMENT_TYPES);
+        }
+        if (req.paymentMethod() != null && !VALID_PAYMENT_METHODS.contains(req.paymentMethod().toUpperCase())) {
+            throw new BadRequestException("Metoda e pagesës e pavlefshme: " + req.paymentMethod()
+                    + ". Vlerat e lejuara: " + VALID_PAYMENT_METHODS);
+        }
+
         SaleContract contract = findContract(req.contractId());
+
+        // Nuk mund të shtohen pagesa në kontratë të anuluar/kompletuar
+        if ("CANCELLED".equals(contract.getStatus())) {
+            throw new InvalidStateException("Nuk mund të krijohet pagesë për kontratë të CANCELLED");
+        }
 
         SalePayment payment = SalePayment.builder()
                 .contract(contract)
                 .amount(req.amount())
-                .currency(req.currency() != null ? req.currency() : "EUR")
-                .paymentType(req.paymentType() != null ? req.paymentType() : "FULL")
-                .paymentMethod(req.paymentMethod())
+                .currency(req.currency() != null ? req.currency().toUpperCase() : "EUR")
+                .paymentType(req.paymentType() != null ? req.paymentType().toUpperCase() : "FULL")
+                .paymentMethod(req.paymentMethod() != null ? req.paymentMethod().toUpperCase() : null)
                 .status("PENDING")
                 .build();
 
         SalePayment saved = paymentRepo.save(payment);
-        log.info("SalePayment u krijua: id={}, contract={}, amount={}", saved.getId(), req.contractId(), req.amount());
+        log.info("SalePayment u krijua: id={}, contract={}, amount={}",
+                saved.getId(), req.contractId(), req.amount());
         return toPaymentResponse(saved);
     }
 
     @Transactional
     public SalePaymentResponse markPaymentAsPaid(Long id, SalePaymentMarkPaidRequest req) {
         assertIsAdminOrAgent();
+
         SalePayment payment = paymentRepo.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Pagesa nuk u gjet: " + id));
 
+        // ── Validime ────────────────────────────────────────────────────────
         if ("PAID".equals(payment.getStatus())) {
-            throw new ConflictException("Pagesa është tashmë e paguar");
+            throw new ConflictException("Pagesa #" + id + " është tashmë e paguar");
+        }
+        if ("FAILED".equals(payment.getStatus()) || "REFUNDED".equals(payment.getStatus())) {
+            throw new InvalidStateException("Pagesa me status '" + payment.getStatus()
+                    + "' nuk mund të shënohet si PAID");
+        }
+        if (req.paidDate() != null && req.paidDate().isAfter(LocalDate.now())) {
+            throw new BadRequestException("Data e pagesës nuk mund të jetë në të ardhmen");
+        }
+        if (req.paymentMethod() != null
+                && !VALID_PAYMENT_METHODS.contains(req.paymentMethod().toUpperCase())) {
+            throw new BadRequestException("Metoda e pagesës e pavlefshme: " + req.paymentMethod());
         }
 
         payment.setStatus("PAID");
         payment.setPaidDate(req.paidDate() != null ? req.paidDate() : LocalDate.now());
-        if (req.paymentMethod()  != null) payment.setPaymentMethod(req.paymentMethod());
+        if (req.paymentMethod()  != null) payment.setPaymentMethod(req.paymentMethod().toUpperCase());
         if (req.transactionRef() != null) payment.setTransactionRef(req.transactionRef());
 
         return toPaymentResponse(paymentRepo.save(payment));
     }
 
-    // ── Helpers ───────────────────────────────────────────────
+    // ── Helpers ───────────────────────────────────────────────────────────────
 
     private SaleListing findActiveListing(Long id) {
         return listingRepo.findByIdAndDeletedAtIsNull(id)
@@ -276,7 +380,7 @@ public class SaleService {
         }
     }
 
-    // ── Mappers ───────────────────────────────────────────────
+    // ── Mappers ───────────────────────────────────────────────────────────────
 
     private SaleListingResponse toListingResponse(SaleListing l) {
         return new SaleListingResponse(

--- a/src/main/java/com/realestate/backend/service/SaleService.java
+++ b/src/main/java/com/realestate/backend/service/SaleService.java
@@ -30,7 +30,7 @@ public class SaleService {
     private final SalePaymentRepository  paymentRepo;
     private final PropertyRepository     propertyRepo;
 
-    // ── Vlerat e lejuara (reflektojnë CHECK constraints në DB) ──────────────
+    // Vlerat e lejuara (reflektojnë CHECK constraints në DB)
     private static final Set<String> VALID_CURRENCIES     = Set.of("EUR", "USD", "ALL", "GBP", "CHF");
     private static final Set<String> VALID_CONTRACT_STATUS = Set.of("PENDING", "COMPLETED", "CANCELLED");
     private static final Set<String> VALID_PAYMENT_TYPES  = Set.of("DEPOSIT", "INSTALLMENT", "FULL", "COMMISSION");
@@ -38,7 +38,7 @@ public class SaleService {
     private static final Set<String> VALID_PAYMENT_METHODS =
             Set.of("BANK_TRANSFER", "CASH", "CARD", "CHECK", "ONLINE");
 
-    // ══════════════════ SALE LISTINGS ═══════════════════════════════════════
+    // ================ SALE LISTINGS ==============================
 
     @Transactional(readOnly = true)
     public Page<SaleListingResponse> getAllListings(Pageable pageable) {
@@ -65,7 +65,7 @@ public class SaleService {
     public SaleListingResponse createListing(SaleListingCreateRequest req) {
         assertIsAdminOrAgent();
 
-        // ── Validime ────────────────────────────────────────────────────────
+        // Validime
         if (req.price() == null || req.price().compareTo(BigDecimal.ZERO) < 0) {
             throw new BadRequestException("Çmimi duhet të jetë 0 ose më i madh");
         }
@@ -99,7 +99,7 @@ public class SaleService {
         SaleListing listing = findActiveListing(id);
         assertCanModifyListing(listing);
 
-        // ── Validime ────────────────────────────────────────────────────────
+        // Validime
         if (req.price() != null && req.price().compareTo(BigDecimal.ZERO) < 0) {
             throw new BadRequestException("Çmimi nuk mund të jetë negativ");
         }
@@ -125,7 +125,7 @@ public class SaleService {
         log.info("SaleListing id={} u fshi (soft delete)", id);
     }
 
-    // ══════════════════ SALE CONTRACTS ═══════════════════════════════════════
+    // ======================= SALE CONTRACTS ==========================
 
     @Transactional(readOnly = true)
     public Page<SaleContractResponse> getAllContracts(Pageable pageable) {
@@ -160,7 +160,7 @@ public class SaleService {
     public SaleContractResponse createContract(SaleContractCreateRequest req) {
         assertIsAdminOrAgent();
 
-        // ── Validime ────────────────────────────────────────────────────────
+        // Validime
         if (req.salePrice() == null || req.salePrice().compareTo(BigDecimal.ZERO) < 0) {
             throw new BadRequestException("Çmimi i shitjes duhet të jetë 0 ose më i madh");
         }
@@ -210,7 +210,7 @@ public class SaleService {
         assertIsAdminOrAgent();
         SaleContract contract = findContract(id);
 
-        // ── Validime ────────────────────────────────────────────────────────
+        // Validime
         if ("COMPLETED".equals(contract.getStatus()) || "CANCELLED".equals(contract.getStatus())) {
             throw new ConflictException("Kontratat e mbyllura nuk mund të ndryshohen");
         }
@@ -241,7 +241,7 @@ public class SaleService {
         assertIsAdminOrAgent();
         SaleContract contract = findContract(id);
 
-        // ── Validime ────────────────────────────────────────────────────────
+        // Validime
         if (!VALID_CONTRACT_STATUS.contains(req.status())) {
             throw new BadRequestException("Statusi i pavlefshëm: " + req.status()
                     + ". Vlerat e lejuara: " + VALID_CONTRACT_STATUS);
@@ -261,7 +261,7 @@ public class SaleService {
         return toContractResponse(findContract(id));
     }
 
-    // ══════════════════ SALE PAYMENTS ════════════════════════════════════════
+    // ======================== SALE PAYMENTS ==========================
 
     @Transactional(readOnly = true)
     public List<SalePaymentResponse> getPaymentsByContract(Long contractId) {
@@ -286,7 +286,7 @@ public class SaleService {
     public SalePaymentResponse createPayment(SalePaymentCreateRequest req) {
         assertIsAdminOrAgent();
 
-        // ── Validime ────────────────────────────────────────────────────────
+        // Validime
         if (req.amount() == null || req.amount().compareTo(BigDecimal.ZERO) < 0) {
             throw new BadRequestException("Shuma duhet të jetë 0 ose më e madhe");
         }
@@ -331,7 +331,7 @@ public class SaleService {
         SalePayment payment = paymentRepo.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Pagesa nuk u gjet: " + id));
 
-        // ── Validime ────────────────────────────────────────────────────────
+        // Validime
         if ("PAID".equals(payment.getStatus())) {
             throw new ConflictException("Pagesa #" + id + " është tashmë e paguar");
         }
@@ -355,7 +355,7 @@ public class SaleService {
         return toPaymentResponse(paymentRepo.save(payment));
     }
 
-    // ── Helpers ───────────────────────────────────────────────────────────────
+    // Helpers
 
     private SaleListing findActiveListing(Long id) {
         return listingRepo.findByIdAndDeletedAtIsNull(id)
@@ -380,7 +380,7 @@ public class SaleService {
         }
     }
 
-    // ── Mappers ───────────────────────────────────────────────────────────────
+    // Mappers
 
     private SaleListingResponse toListingResponse(SaleListing l) {
         return new SaleListingResponse(

--- a/src/main/java/com/realestate/backend/service/UserService.java
+++ b/src/main/java/com/realestate/backend/service/UserService.java
@@ -2,11 +2,7 @@ package com.realestate.backend.service;
 
 import com.realestate.backend.dto.user.UserProfileDtos.*;
 import com.realestate.backend.entity.User;
-import com.realestate.backend.entity.enums.Role;
-import com.realestate.backend.exception.ConflictException;
-import com.realestate.backend.exception.ForbiddenException;
-import com.realestate.backend.exception.ResourceNotFoundException;
-import com.realestate.backend.exception.UnauthorizedException;
+import com.realestate.backend.exception.*;
 import com.realestate.backend.multitenancy.TenantContext;
 import com.realestate.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -26,7 +23,11 @@ public class UserService {
     private final UserRepository  userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    // ── Lista e userëve të tenant-it ──────────────────────────
+    // ── Vlera të lejuara — reflektojnë CHECK constraints në DB ───────────────
+    // role VARCHAR(20) CHECK (role IN ('ADMIN','AGENT','CLIENT'))
+    private static final Set<String> VALID_ROLES = Set.of("ADMIN", "AGENT", "CLIENT");
+
+    // ── Lista e userëve të tenant-it (ADMIN) ──────────────────────────────────
     @Transactional(readOnly = true)
     public List<UserResponse> getAllUsersInTenant() {
         assertIsAdmin();
@@ -34,7 +35,7 @@ public class UserService {
                 .stream().map(this::toResponse).toList();
     }
 
-    // ── Merr user sipas ID ────────────────────────────────────
+    // ── Merr user sipas ID ────────────────────────────────────────────────────
     @Transactional(readOnly = true)
     public UserResponse getById(Long id) {
         User user = findUser(id);
@@ -42,30 +43,50 @@ public class UserService {
         return toResponse(user);
     }
 
-    // ── Profili im ────────────────────────────────────────────
+    // ── Profili im ────────────────────────────────────────────────────────────
     @Transactional(readOnly = true)
     public UserResponse getMyProfile() {
         return toResponse(findUser(TenantContext.getUserId()));
     }
 
-    // ── Ndrysho profilin tim ──────────────────────────────────
+    // ── Ndrysho profilin tim ──────────────────────────────────────────────────
     @Transactional
     public UserResponse updateMyProfile(UserUpdateRequest req) {
         User user = findUser(TenantContext.getUserId());
 
-        if (req.email() != null && !req.email().equals(user.getEmail())) {
-            if (userRepository.existsByEmail(req.email())) {
+        // ── Validime ─────────────────────────────────────────────────────────
+        if (req.firstName() != null && req.firstName().isBlank()) {
+            throw new BadRequestException("Emri nuk mund të jetë bosh");
+        }
+        if (req.lastName() != null && req.lastName().isBlank()) {
+            throw new BadRequestException("Mbiemri nuk mund të jetë bosh");
+        }
+        if (req.firstName() != null && req.firstName().length() > 50) {
+            throw new BadRequestException("Emri nuk mund të jetë më i gjatë se 50 karaktere");
+        }
+        if (req.lastName() != null && req.lastName().length() > 50) {
+            throw new BadRequestException("Mbiemri nuk mund të jetë më i gjatë se 50 karaktere");
+        }
+        if (req.email() != null) {
+            if (!req.email().matches("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")) {
+                throw new BadRequestException("Formati i email-it është i pavlefshëm");
+            }
+            if (req.email().length() > 150) {
+                throw new BadRequestException("Email nuk mund të jetë më i gjatë se 150 karaktere");
+            }
+            if (!req.email().equals(user.getEmail()) && userRepository.existsByEmail(req.email())) {
                 throw new ConflictException("Email ekziston tashmë: " + req.email());
             }
-            user.setEmail(req.email());
         }
-        if (req.firstName() != null) user.setFirstName(req.firstName());
-        if (req.lastName()  != null) user.setLastName(req.lastName());
+
+        if (req.email()     != null) user.setEmail(req.email().trim().toLowerCase());
+        if (req.firstName() != null) user.setFirstName(req.firstName().trim());
+        if (req.lastName()  != null) user.setLastName(req.lastName().trim());
 
         return toResponse(userRepository.save(user));
     }
 
-    // ── Ndrysho fjalëkalimin ──────────────────────────────────
+    // ── Ndrysho fjalëkalimin ──────────────────────────────────────────────────
     @Transactional
     public void changePassword(ChangePasswordRequest req) {
         User user = findUser(TenantContext.getUserId());
@@ -74,41 +95,73 @@ public class UserService {
             throw new UnauthorizedException("Fjalëkalimi aktual është i gabuar");
         }
 
+        // ── Validime ─────────────────────────────────────────────────────────
+        // min 8 karaktere + shkronja + numër — konfirmuar nga @Pattern në DTO
+        // por e kontrollojmë edhe këtu si shtresë shtesë
+        if (req.newPassword().length() < 8) {
+            throw new BadRequestException("Fjalëkalimi i ri duhet të ketë minimum 8 karaktere");
+        }
+        if (!req.newPassword().matches("^(?=.*[A-Za-z])(?=.*\\d).+$")) {
+            throw new BadRequestException(
+                    "Fjalëkalimi i ri duhet të përmbajë të paktën një shkronjë dhe një numër");
+        }
+        if (passwordEncoder.matches(req.newPassword(), user.getPassword())) {
+            throw new BadRequestException(
+                    "Fjalëkalimi i ri nuk mund të jetë i njëjtë me fjalëkalimin aktual");
+        }
+
         user.setPassword(passwordEncoder.encode(req.newPassword()));
         userRepository.save(user);
         log.info("Fjalëkalimi u ndryshua për user id={}", user.getId());
     }
 
-    // ── ADMIN: aktivo/çaktivizo user ──────────────────────────
+    // ── ADMIN: aktivo / çaktivizo user ───────────────────────────────────────
     @Transactional
     public UserResponse setUserActive(Long id, UserStatusRequest req) {
         assertIsAdmin();
+
         User user = findUser(id);
+
+        // Nuk mund të çaktivizosh veten
+        if (user.getId().equals(TenantContext.getUserId()) && Boolean.FALSE.equals(req.isActive())) {
+            throw new ConflictException("Nuk mund të çaktivizoni llogarinë tuaj");
+        }
+
         user.setIsActive(req.isActive());
-        log.info("User id={} u {}aktivizua", id, req.isActive() ? "" : "ç");
+        log.info("User id={} u {}aktivizua nga admin id={}",
+                id, req.isActive() ? "" : "ç", TenantContext.getUserId());
         return toResponse(userRepository.save(user));
     }
 
-    // ── ADMIN: ndrysho rolin ──────────────────────────────────
+    // ── ADMIN: ndrysho rolin ──────────────────────────────────────────────────
     @Transactional
     public UserResponse changeRole(Long id, UserRoleRequest req) {
         assertIsAdmin();
+
         User user = findUser(id);
 
-        // Parandalon ADMIN-in e vetëm nga ndryshimi i rolit të tij
+        // Nuk mund të ndryshosh rolin tënd
         if (user.getId().equals(TenantContext.getUserId())) {
             throw new ConflictException("Nuk mund të ndryshoni rolin tuaj");
         }
 
+        // ── Validime ─────────────────────────────────────────────────────────
+        // Enum Role garanton vlerat e vlefshme — por kontrollo nëse null
+        if (req.role() == null) {
+            throw new BadRequestException("Roli është i detyrueshëm. Vlerat: " + VALID_ROLES);
+        }
+
         user.setRole(req.role());
-        log.info("Roli i user id={} u ndryshua në {}", id, req.role());
+        log.info("Roli i user id={} u ndryshua në {} nga admin id={}",
+                id, req.role(), TenantContext.getUserId());
         return toResponse(userRepository.save(user));
     }
 
-    // ── ADMIN: soft delete ────────────────────────────────────
+    // ── ADMIN: soft delete ────────────────────────────────────────────────────
     @Transactional
     public void deleteUser(Long id) {
         assertIsAdmin();
+
         User user = findUser(id);
 
         if (user.getId().equals(TenantContext.getUserId())) {
@@ -118,10 +171,10 @@ public class UserService {
         user.setDeletedAt(LocalDateTime.now());
         user.setIsActive(false);
         userRepository.save(user);
-        log.info("User id={} u fshi (soft delete)", id);
+        log.info("User id={} u fshi (soft delete) nga admin id={}", id, TenantContext.getUserId());
     }
 
-    // ── Helpers ───────────────────────────────────────────────
+    // ── Helpers ───────────────────────────────────────────────────────────────
 
     private User findUser(Long id) {
         return userRepository.findById(id)
@@ -142,7 +195,7 @@ public class UserService {
         }
     }
 
-    // ── Mapper ────────────────────────────────────────────────
+    // ── Mapper ────────────────────────────────────────────────────────────────
 
     private UserResponse toResponse(User u) {
         return new UserResponse(

--- a/src/main/java/com/realestate/backend/service/UserService.java
+++ b/src/main/java/com/realestate/backend/service/UserService.java
@@ -23,11 +23,11 @@ public class UserService {
     private final UserRepository  userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    // ── Vlera të lejuara — reflektojnë CHECK constraints në DB ───────────────
+    //  Vlera të lejuara — reflektojnë CHECK constraints në DB
     // role VARCHAR(20) CHECK (role IN ('ADMIN','AGENT','CLIENT'))
     private static final Set<String> VALID_ROLES = Set.of("ADMIN", "AGENT", "CLIENT");
 
-    // ── Lista e userëve të tenant-it (ADMIN) ──────────────────────────────────
+    // Lista e userëve të tenant-it (ADMIN)
     @Transactional(readOnly = true)
     public List<UserResponse> getAllUsersInTenant() {
         assertIsAdmin();
@@ -35,7 +35,7 @@ public class UserService {
                 .stream().map(this::toResponse).toList();
     }
 
-    // ── Merr user sipas ID ────────────────────────────────────────────────────
+    // Merr user sipas ID
     @Transactional(readOnly = true)
     public UserResponse getById(Long id) {
         User user = findUser(id);
@@ -43,18 +43,18 @@ public class UserService {
         return toResponse(user);
     }
 
-    // ── Profili im ────────────────────────────────────────────────────────────
+    // Profili im
     @Transactional(readOnly = true)
     public UserResponse getMyProfile() {
         return toResponse(findUser(TenantContext.getUserId()));
     }
 
-    // ── Ndrysho profilin tim ──────────────────────────────────────────────────
+    // Ndrysho profilin tim
     @Transactional
     public UserResponse updateMyProfile(UserUpdateRequest req) {
         User user = findUser(TenantContext.getUserId());
 
-        // ── Validime ─────────────────────────────────────────────────────────
+        // Validime
         if (req.firstName() != null && req.firstName().isBlank()) {
             throw new BadRequestException("Emri nuk mund të jetë bosh");
         }
@@ -86,7 +86,7 @@ public class UserService {
         return toResponse(userRepository.save(user));
     }
 
-    // ── Ndrysho fjalëkalimin ──────────────────────────────────────────────────
+    // Ndrysho fjalëkalimin
     @Transactional
     public void changePassword(ChangePasswordRequest req) {
         User user = findUser(TenantContext.getUserId());
@@ -95,7 +95,7 @@ public class UserService {
             throw new UnauthorizedException("Fjalëkalimi aktual është i gabuar");
         }
 
-        // ── Validime ─────────────────────────────────────────────────────────
+        // Validime
         // min 8 karaktere + shkronja + numër — konfirmuar nga @Pattern në DTO
         // por e kontrollojmë edhe këtu si shtresë shtesë
         if (req.newPassword().length() < 8) {
@@ -115,7 +115,7 @@ public class UserService {
         log.info("Fjalëkalimi u ndryshua për user id={}", user.getId());
     }
 
-    // ── ADMIN: aktivo / çaktivizo user ───────────────────────────────────────
+    // ADMIN: aktivo / çaktivizo user
     @Transactional
     public UserResponse setUserActive(Long id, UserStatusRequest req) {
         assertIsAdmin();
@@ -133,7 +133,7 @@ public class UserService {
         return toResponse(userRepository.save(user));
     }
 
-    // ── ADMIN: ndrysho rolin ──────────────────────────────────────────────────
+    // ADMIN: ndrysho rolin
     @Transactional
     public UserResponse changeRole(Long id, UserRoleRequest req) {
         assertIsAdmin();
@@ -145,7 +145,7 @@ public class UserService {
             throw new ConflictException("Nuk mund të ndryshoni rolin tuaj");
         }
 
-        // ── Validime ─────────────────────────────────────────────────────────
+        // Validime
         // Enum Role garanton vlerat e vlefshme — por kontrollo nëse null
         if (req.role() == null) {
             throw new BadRequestException("Roli është i detyrueshëm. Vlerat: " + VALID_ROLES);
@@ -157,7 +157,7 @@ public class UserService {
         return toResponse(userRepository.save(user));
     }
 
-    // ── ADMIN: soft delete ────────────────────────────────────────────────────
+    // ADMIN: soft delete
     @Transactional
     public void deleteUser(Long id) {
         assertIsAdmin();
@@ -174,7 +174,7 @@ public class UserService {
         log.info("User id={} u fshi (soft delete) nga admin id={}", id, TenantContext.getUserId());
     }
 
-    // ── Helpers ───────────────────────────────────────────────────────────────
+    // Helpers
 
     private User findUser(Long id) {
         return userRepository.findById(id)
@@ -195,7 +195,7 @@ public class UserService {
         }
     }
 
-    // ── Mapper ────────────────────────────────────────────────────────────────
+    // Mapper
 
     private UserResponse toResponse(User u) {
         return new UserResponse(


### PR DESCRIPTION
Ky PR shton check constraints në databazë për të përmirësuar integritetin dhe validimin e të dhënave në nivel databaze.

Përfshin:
- Shtimin e constraints për fusha numerike (p.sh. budget >= 0, experience_years 0–60, çmimi>=0 etj.)
- Validim për fusha që lidhen me enum values (status, type, source)
- Përmirësim të strukturës së databazës për të parandaluar të dhëna të pavlefshme

Këto ndryshime sigurojnë që edhe në rast se validimi në backend dështon, databaza të mos lejojë ruajtjen e të dhënave të pasakta.

Closes #33 