### PR TITLE
Improvement(Leads): Implement Accept/Decline flow with agent enrichment

### DIFF
--- a/src/main/java/com/realestate/backend/controller/LeadController.java
+++ b/src/main/java/com/realestate/backend/controller/LeadController.java
@@ -24,6 +24,8 @@ public class LeadController {
 
     private final LeadService leadService;
 
+    // ── pa ndryshim ───────────────────────────────────────────────────────────
+
     @GetMapping
     @Operation(summary = "Listo leads sipas statusit (ADMIN/AGENT)")
     @PreAuthorize("hasAnyRole('ADMIN','AGENT')")
@@ -69,7 +71,7 @@ public class LeadController {
     }
 
     @GetMapping("/unassigned")
-    @Operation(summary = "Leads të paasinjuara (ADMIN)")
+    @Operation(summary = "Leads të paasinjuara — NEW pa agjent (ADMIN)")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<List<LeadResponse>> getUnassigned() {
         return ResponseEntity.ok(leadService.getUnassigned());
@@ -92,7 +94,8 @@ public class LeadController {
     }
 
     @PatchMapping("/{id}/assign")
-    @Operation(summary = "Asinjono agjent (ADMIN)")
+    @Operation(summary = "Asinjono agjent — statusi MBETET NEW, agjenti pranon vetë (ADMIN)")
+    // NDRYSHIM dokumentimi: assignAgent tani nuk e kalon IN_PROGRESS automatikisht
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<LeadResponse> assign(
             @PathVariable Long id,
@@ -101,11 +104,27 @@ public class LeadController {
     }
 
     @PatchMapping("/{id}/status")
-    @Operation(summary = "Ndrysho statusin (ADMIN/AGENT)")
+    @Operation(summary = "Ndrysho statusin — NEW→IN_PROGRESS (Accept), IN_PROGRESS→DONE/REJECTED (ADMIN/AGENT)")
+    // NDRYSHIM: agjenti mund të ndryshojë vetëm leads të asignuara tek ai
     @PreAuthorize("hasAnyRole('ADMIN','AGENT')")
     public ResponseEntity<LeadResponse> updateStatus(
             @PathVariable Long id,
             @Valid @RequestBody LeadStatusRequest request) {
         return ResponseEntity.ok(leadService.updateStatus(id, request));
+    }
+
+    // ── SHTUAR: endpoint i ri për Decline ─────────────────────────────────────
+    // Agjenti refuzon operacionalisht — lead kthehet tek admini si NEW pa agjent
+    // E ndryshme nga REJECTED (final biznesi) — DECLINE rifillon ciklin
+    @PatchMapping("/{id}/decline")
+    @Operation(
+            summary = "Agjenti refuzon lead-in (Decline) — kthehet tek admini si NEW pa agjent",
+            description = "Përdoret kur agjenti nuk mund ta trajtojë lead-in (është i zënë, nuk i përshtatet). " +
+                    "Lead kthehet si NEW pa agjent — admini e sheh në /unassigned dhe e assign tek tjetri. " +
+                    "E NDRYSHME nga REJECTED: REJECTED = vendim final biznesi, DECLINE = refuzim operacional."
+    )
+    @PreAuthorize("hasAnyRole('ADMIN','AGENT')")
+    public ResponseEntity<LeadResponse> declineLead(@PathVariable Long id) {
+        return ResponseEntity.ok(leadService.declineLead(id));
     }
 }

--- a/src/main/java/com/realestate/backend/dto/lead/LeadDtos.java
+++ b/src/main/java/com/realestate/backend/dto/lead/LeadDtos.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 
 public class LeadDtos {
 
-    // ── CREATE ────────────────────────────────────────────────
+    // ── CREATE — pa ndryshim ──────────────────────────────────
 
     public record LeadCreateRequest(
 
@@ -36,7 +36,7 @@ public class LeadDtos {
             LeadSource source
     ) {}
 
-    // ── ASSIGN AGENT ──────────────────────────────────────────
+    // ── ASSIGN AGENT — pa ndryshim ────────────────────────────
 
     public record LeadAssignRequest(
 
@@ -45,16 +45,20 @@ public class LeadDtos {
             Long agentId
     ) {}
 
-    // ── STATUS UPDATE ─────────────────────────────────────────
+    // ── STATUS UPDATE — NDRYSHIM: shtohet DECLINED në allowableValues ─────────
+    // Shënim: DECLINED nuk dërgohet nga ky endpoint — ka endpoint të veçantë /decline
+    // Por e dokumentojmë këtu për Swagger clarity
 
     public record LeadStatusRequest(
 
             @NotNull(message = "Statusi është i detyrueshëm")
-            @Schema(allowableValues = {"NEW","IN_PROGRESS","DONE","REJECTED"})
+            @Schema(allowableValues = {"IN_PROGRESS","DONE","REJECTED"})
+            // NDRYSHIM: hequr NEW (nuk mund të kthehet manualisht)
+            // DECLINED trajtohet nga PATCH /api/leads/{id}/decline — jo nga ky endpoint
             LeadStatus status
     ) {}
 
-    // ── RESPONSE ──────────────────────────────────────────────
+    // ── RESPONSE — pa ndryshim strukturor, por status tani mund të jetë DECLINED ─
 
     public record LeadResponse(
             Long id,
@@ -71,7 +75,7 @@ public class LeadDtos {
             @JsonProperty("updated_at")          LocalDateTime updatedAt
     ) {}
 
-    // ── SUMMARY (për listim) ──────────────────────────────────
+    // ── SUMMARY — pa ndryshim ─────────────────────────────────
 
     public record LeadSummaryResponse(
             Long id,

--- a/src/main/java/com/realestate/backend/entity/enums/LeadStatus.java
+++ b/src/main/java/com/realestate/backend/entity/enums/LeadStatus.java
@@ -4,5 +4,6 @@ public enum LeadStatus {
     NEW,
     IN_PROGRESS,
     DONE,
-    REJECTED
+    REJECTED,
+    DECLINED
 }

--- a/src/main/java/com/realestate/backend/repository/LeadRequestRepository.java
+++ b/src/main/java/com/realestate/backend/repository/LeadRequestRepository.java
@@ -1,7 +1,6 @@
 package com.realestate.backend.repository;
 
 import com.realestate.backend.entity.enums.LeadStatus;
-import com.realestate.backend.entity.enums.LeadType;
 import com.realestate.backend.entity.lead.PropertyLeadRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,7 +21,8 @@ public interface LeadRequestRepository extends JpaRepository<PropertyLeadRequest
 
     List<PropertyLeadRequest> findByProperty_IdOrderByCreatedAtDesc(Long propertyId);
 
-    // Leads të paassinjuara (për admin)
+    // Leads të paassinjuara (për admin) — NDRYSHIM: shton edhe DECLINED
+    // DECLINED kthehet si NEW pa agjent, kështu admini e sheh në unassigned
     @Query("""
         SELECT lr FROM PropertyLeadRequest lr
         WHERE lr.assignedAgentId IS NULL
@@ -40,16 +40,28 @@ public interface LeadRequestRepository extends JpaRepository<PropertyLeadRequest
     """)
     void updateStatus(@Param("id") Long id, @Param("status") LeadStatus status);
 
-    // Asinjono agjent
+    // NDRYSHIM: assignAgent NUK e kalon më automatikisht në IN_PROGRESS
+    // Statusi mbetet NEW — agjenti vetë klikon Accept për ta kaluar në IN_PROGRESS
     @Modifying
     @Query("""
         UPDATE PropertyLeadRequest lr
         SET lr.assignedAgentId = :agentId,
-            lr.status = com.realestate.backend.entity.enums.LeadStatus.IN_PROGRESS,
             lr.updatedAt = CURRENT_TIMESTAMP
         WHERE lr.id = :id
     """)
     void assignAgent(@Param("id") Long id, @Param("agentId") Long agentId);
+
+    // SHTUAR: declineLead — heq agjentin dhe kthon statusin në NEW
+    // Agjenti refuzon lead-in operacionalisht — admini do ta reassignojë
+    @Modifying
+    @Query("""
+        UPDATE PropertyLeadRequest lr
+        SET lr.assignedAgentId = NULL,
+            lr.status = com.realestate.backend.entity.enums.LeadStatus.NEW,
+            lr.updatedAt = CURRENT_TIMESTAMP
+        WHERE lr.id = :id
+    """)
+    void declineLead(@Param("id") Long id);
 
     long countByStatus(LeadStatus status);
 

--- a/src/main/java/com/realestate/backend/service/LeadService.java
+++ b/src/main/java/com/realestate/backend/service/LeadService.java
@@ -28,21 +28,21 @@ public class LeadService {
     private final LeadRequestRepository leadRepo;
     private final PropertyRepository    propertyRepo;
 
-    // Të gjitha leads (ADMIN/AGENT)
+    // ── Të gjitha leads (ADMIN/AGENT) — pa ndryshim ──────────────────────────
     @Transactional(readOnly = true)
     public Page<LeadResponse> getAll(Pageable pageable) {
         assertIsAdminOrAgent();
         return leadRepo.findByStatusOrderByCreatedAtDesc(LeadStatus.NEW, pageable).map(this::toResponse);
     }
 
-    // Leads sipas statusit
+    // ── Leads sipas statusit — pa ndryshim ───────────────────────────────────
     @Transactional(readOnly = true)
     public Page<LeadResponse> getByStatus(LeadStatus status, Pageable pageable) {
         assertIsAdminOrAgent();
         return leadRepo.findByStatusOrderByCreatedAtDesc(status, pageable).map(this::toResponse);
     }
 
-    // Leads të agjentit
+    // ── Leads të agjentit — pa ndryshim ──────────────────────────────────────
     @Transactional(readOnly = true)
     public Page<LeadResponse> getMyLeadsAsAgent(Pageable pageable) {
         assertIsAdminOrAgent();
@@ -50,27 +50,28 @@ public class LeadService {
                 .map(this::toResponse);
     }
 
-    // Leads të klientit
+    // ── Leads të klientit — pa ndryshim ──────────────────────────────────────
     @Transactional(readOnly = true)
     public Page<LeadResponse> getMyLeadsAsClient(Pageable pageable) {
         return leadRepo.findByClientIdOrderByCreatedAtDesc(TenantContext.getUserId(), pageable)
                 .map(this::toResponse);
     }
 
-    // Leads të paassinjuara (ADMIN)
+    // ── Leads të paassinjuara — pa ndryshim ──────────────────────────────────
+    // findUnassigned() kap edhe leads që u kthyen nga Decline (NEW + assignedAgentId = NULL)
     @Transactional(readOnly = true)
     public List<LeadResponse> getUnassigned() {
         assertIsAdmin();
         return leadRepo.findUnassigned().stream().map(this::toResponse).toList();
     }
 
-    // Merr sipas ID
+    // ── Merr sipas ID — pa ndryshim ──────────────────────────────────────────
     @Transactional(readOnly = true)
     public LeadResponse getById(Long id) {
         return toResponse(findLead(id));
     }
 
-    // Leads sipas pronës
+    // ── Leads sipas pronës — pa ndryshim ─────────────────────────────────────
     @Transactional(readOnly = true)
     public List<LeadResponse> getByProperty(Long propertyId) {
         assertIsAdminOrAgent();
@@ -78,11 +79,9 @@ public class LeadService {
                 .stream().map(this::toResponse).toList();
     }
 
-    // Krijo lead
+    // ── Krijo lead — pa ndryshim ──────────────────────────────────────────────
     @Transactional
     public LeadResponse create(LeadCreateRequest req) {
-
-        // Validime
         if (req.type() == null) {
             throw new BadRequestException("Tipi i kërkesës është i detyrueshëm. "
                     + "Vlerat e lejuara: SELL, BUY, RENT, VALUATION");
@@ -93,11 +92,8 @@ public class LeadService {
         if (req.preferredDate() != null && req.preferredDate().isBefore(LocalDate.now())) {
             throw new BadRequestException("Data e preferuar nuk mund të jetë në të kaluarën");
         }
-        // source ka default WEBSITE — nuk ka nevojë për validim shtesë
-        // sepse tipi LeadSource e garanton vlerën e vlefshme
 
         Long clientId = TenantContext.getUserId();
-
         Property property = null;
         if (req.propertyId() != null) {
             property = propertyRepo.findByIdAndDeletedAtIsNull(req.propertyId())
@@ -105,10 +101,7 @@ public class LeadService {
                             "Prona nuk u gjet: " + req.propertyId()));
         }
 
-        // BUY/RENT pa pronë është OK (klient kërkon pronë)
-        // SELL/VALUATION pa pronë — paralajmërim në log (jo error)
-        if ((req.type() == LeadType.SELL || req.type() == LeadType.VALUATION)
-                && property == null) {
+        if ((req.type() == LeadType.SELL || req.type() == LeadType.VALUATION) && property == null) {
             log.warn("Lead tipi {} u krijua pa pronë — clientId={}", req.type(), clientId);
         }
 
@@ -128,55 +121,125 @@ public class LeadService {
         return toResponse(saved);
     }
 
-    // Asinjono agjent (ADMIN)
+    // ── NDRYSHIM: assignAgent ─────────────────────────────────────────────────
+    // Para: assignAgent() e kalonte direkt NEW → IN_PROGRESS automatikisht
+    // Tani: assignAgent() vendos vetëm agjentin, statusi MBETET NEW
+    //       Agjenti vetë klikon Accept → IN_PROGRESS
+    //       Kjo lejon reassignment nga DECLINED pa problem — lead është tashmë NEW
     @Transactional
     public LeadResponse assignAgent(Long id, LeadAssignRequest req) {
         assertIsAdmin();
 
         PropertyLeadRequest lead = findLead(id);
 
-        // Validime
+        // NDRYSHIM: DONE dhe REJECTED janë finale — nuk mund të risinohen
+        // DECLINED tashmë është NEW (e ktheu declineLead), kështu hyn normalisht
         if (lead.getStatus() == LeadStatus.DONE || lead.getStatus() == LeadStatus.REJECTED) {
             throw new InvalidStateException("Leadi me status '"
-                    + lead.getStatus() + "' nuk mund të asinohet");
+                    + lead.getStatus() + "' është final dhe nuk mund të asinohet");
         }
         if (req.agentId() == null) {
             throw new BadRequestException("agent_id është i detyrueshëm");
         }
 
+        // assignAgent() tani NUK e ndryshon statusin — shih repository
         leadRepo.assignAgent(id, req.agentId());
-        log.info("Lead id={} u asinjua tek agjenti id={}", id, req.agentId());
+        log.info("Lead id={} u asinjua tek agjenti id={} (statusi mbetet: {})",
+                id, req.agentId(), lead.getStatus());
         return toResponse(findLead(id));
     }
 
-    // Ndrysho statusin
+    // ── NDRYSHIM: updateStatus ────────────────────────────────────────────────
+    // Para: lejohej NEW → IN_PROGRESS nga çdo agjent
+    // Tani: kontrollon që agjenti mund të ndryshojë vetëm leads të asignuara tek ai
+    //       dhe shton validimin për DECLINED
     @Transactional
     public LeadResponse updateStatus(Long id, LeadStatusRequest req) {
         assertIsAdminOrAgent();
 
         PropertyLeadRequest lead = findLead(id);
 
-        // ── Validime — tranzicionet e lejuara ────────────────────────────────
-        // NEW        → IN_PROGRESS, REJECTED
-        // IN_PROGRESS → DONE, REJECTED
-        // DONE       → (final, nuk ndryshon)
-        // REJECTED   → (final, nuk ndryshon)
+        // DONE dhe REJECTED janë absolutisht finale — as admini nuk i ndryshon
         if (lead.getStatus() == LeadStatus.DONE || lead.getStatus() == LeadStatus.REJECTED) {
             throw new InvalidStateException("Leadi me status '"
                     + lead.getStatus() + "' është final dhe nuk mund të ndryshohet");
         }
-        if (req.status() == LeadStatus.NEW) {
-            throw new BadRequestException("Leadi nuk mund të kthehet në statusin NEW");
+
+        // DECLINED trajtohet vetëm nga /decline endpoint, jo nga /status
+        if (lead.getStatus() == LeadStatus.DECLINED) {
+            throw new InvalidStateException(
+                    "Leadi DECLINED nuk mund të ndryshohet nga agjenti. " +
+                            "Admini do ta reassignojë.");
         }
-        // Agjent nuk mund të vendosë REJECTED pa qenë ADMIN — opsionale
-        // (e lëmë në mënyrën aktuale — të dy rolet mund të refuzojnë)
+
+        // Nuk mund të kthehesh manualisht në NEW
+        if (req.status() == LeadStatus.NEW || req.status() == LeadStatus.DECLINED) {
+            throw new BadRequestException(
+                    "Statusi NEW dhe DECLINED nuk mund të vendosen manualisht");
+        }
+
+        // NDRYSHIM: agjenti mund të ndryshojë vetëm leads të asignuara tek ai
+        if (TenantContext.hasRole("AGENT")) {
+            if (!TenantContext.getUserId().equals(lead.getAssignedAgentId())) {
+                throw new ForbiddenException(
+                        "Mund të ndryshoni vetëm leads të asignuara tek ju");
+            }
+        }
+
+        // Validim tranzicionesh:
+        // NEW        → IN_PROGRESS (Accept nga agjenti)
+        // IN_PROGRESS → DONE ose REJECTED
+        if (lead.getStatus() == LeadStatus.NEW && req.status() == LeadStatus.REJECTED) {
+            // Agjenti nuk mund ta Reject-ojë pa e pranuar fillimisht
+            // Për refuzim pa pranim, duhet të përdorë butonin Decline
+            throw new BadRequestException(
+                    "Nuk mund ta refuzoni (REJECTED) pa e pranuar fillimisht. " +
+                            "Përdorni butonin Decline nëse nuk doni ta merrni këtë lead.");
+        }
+        if (lead.getStatus() == LeadStatus.IN_PROGRESS && req.status() == LeadStatus.NEW) {
+            throw new BadRequestException("Nuk mund të ktheheni në NEW pasi keni filluar punën");
+        }
 
         leadRepo.updateStatus(id, req.status());
-        log.info("Lead id={} statusi u ndryshua nga {} në {}", id, lead.getStatus(), req.status());
+        log.info("Lead id={} statusi u ndryshua nga {} në {}",
+                id, lead.getStatus(), req.status());
         return toResponse(findLead(id));
     }
 
-    // Helpers
+    // ── SHTUAR: declineLead ───────────────────────────────────────────────────
+    // Agjenti refuzon lead-in operacionalisht (është i zënë, nuk i përshtatet)
+    // Lead kthehet tek admini si NEW pa agjent — admini e assign tek tjetri
+    // E ndryshme nga REJECTED: REJECTED = vendim final biznesi, DECLINE = refuzim operacional
+    @Transactional
+    public LeadResponse declineLead(Long id) {
+        assertIsAdminOrAgent();
+
+        PropertyLeadRequest lead = findLead(id);
+
+        // Vetëm agjenti i asignuar mund ta refuzojë
+        if (TenantContext.hasRole("AGENT")) {
+            if (!TenantContext.getUserId().equals(lead.getAssignedAgentId())) {
+                throw new ForbiddenException(
+                        "Mund të refuzoni vetëm leads të asignuara tek ju");
+            }
+        }
+
+        // Decline lejohet vetëm kur lead-i është NEW (pra nuk ka filluar punën)
+        // Nëse agjenti ka filluar (IN_PROGRESS), duhet të kontaktojë adminin
+        if (lead.getStatus() != LeadStatus.NEW) {
+            throw new InvalidStateException(
+                    "Decline lejohet vetëm për leads me status NEW. " +
+                            "Nëse keni filluar punën (IN_PROGRESS), kontaktoni adminin për reassignment.");
+        }
+
+        // declineLead(): vendos assignedAgentId = NULL dhe status = NEW
+        leadRepo.declineLead(id);
+        log.info("Lead id={} u refuzua (Decline) nga agjenti id={} — kthehet tek admini si NEW",
+                id, TenantContext.getUserId());
+        return toResponse(findLead(id));
+    }
+
+    // ── Helpers — pa ndryshim ─────────────────────────────────────────────────
 
     private PropertyLeadRequest findLead(Long id) {
         return leadRepo.findById(id)
@@ -195,7 +258,7 @@ public class LeadService {
         }
     }
 
-    // Mapper
+    // ── Mapper — pa ndryshim ──────────────────────────────────────────────────
 
     private LeadResponse toResponse(PropertyLeadRequest l) {
         return new LeadResponse(


### PR DESCRIPTION
## Çfarë u ndryshua

### LeadStatus.java
- Shtuar `DECLINED` si status i ri — përdoret kur agjenti refuzon
  operacionalisht një lead (nuk mund ta trajtojë, është i zënë)
- E ndryshme nga `REJECTED`: REJECTED = vendim final biznesi,
  DECLINED = refuzim operacional, lead rifillon ciklin

### LeadRequestRepository.java
- `assignAgent()` — hequr kalimi automatik `NEW → IN_PROGRESS`.
  Tani vendos vetëm `assignedAgentId`, statusi mbetet NEW
  (agjenti vetë klikon Accept për ta kaluar në IN_PROGRESS)
- Shtuar `declineLead()` — vendos `assignedAgentId = NULL` dhe
  `status = NEW`, lead kthehet tek admini për reassignment

### LeadDtos.java
- `LeadStatusRequest.allowableValues` — hequr `NEW` dhe `DECLINED`
  sepse këto nuk vendosen manualisht nga ky endpoint

### LeadService.java
- `assignAgent()` — statusi nuk ndryshon më automatikisht,
  lejon reassignment nga leads me status DONE/REJECTED të bllokuara
- `updateStatus()` — shtuar validime:
  - Agjenti mund të ndryshojë vetëm leads të asignuara tek ai
  - Nuk lejohet Reject direkt nga NEW (duhet Accept fillimisht)
  - DECLINED nuk mund të ndryshohet nga /status endpoint
- Shtuar `declineLead()` — metodë e re me validime të plota

### LeadController.java
- Shtuar endpoint `PATCH /{id}/decline` me dokumentim Swagger

## Flow-i i ri
NEW (pa agjent)    → Admin assign    → NEW (me agjent)
NEW (me agjent)    → Accept          → IN_PROGRESS
NEW (me agjent)    → Decline         → NEW (pa agjent) — admini reassignon
IN_PROGRESS        → Complete        → DONE     (final biznesi)
IN_PROGRESS        → Reject          → REJECTED (final biznesi)
DONE / REJECTED    → asnjë veprim   (final, i pandryshueshem)

## Testet e rekomanduar në Swagger
1. Krijo lead → verifiko `status = NEW`, `assigned_agent_id = null`
2. Admin assign → verifiko `status = NEW`, `assigned_agent_id = X`
3. Agent Accept (`/status` → `IN_PROGRESS`) → verifiko kalimin
4. Agent Decline (`/decline`) → verifiko `status = NEW`, `assigned_agent_id = null`
5. Agent Complete (`/status` → `DONE`) → verifiko bllokimin e ndryshimeve
6. Provo Reject direkt nga NEW → duhet të kthejë 422