### PR TITLE
Improvement(Leads): Added endpoint for changing lead's property_id

### DIFF
--- a/src/main/java/com/realestate/backend/controller/LeadController.java
+++ b/src/main/java/com/realestate/backend/controller/LeadController.java
@@ -14,6 +14,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/leads")
@@ -126,5 +127,14 @@ public class LeadController {
     @PreAuthorize("hasAnyRole('ADMIN','AGENT')")
     public ResponseEntity<LeadResponse> declineLead(@PathVariable Long id) {
         return ResponseEntity.ok(leadService.declineLead(id));
+    }
+
+    @PatchMapping("/{id}/property")
+    @Operation(summary = "Lidh lead-in me një pronë (ADMIN/AGENT)")
+    @PreAuthorize("hasAnyRole('ADMIN','AGENT')")
+    public ResponseEntity<LeadResponse> linkProperty(
+            @PathVariable Long id,
+            @RequestBody Map<String, Long> body) {
+        return ResponseEntity.ok(leadService.linkProperty(id, body.get("property_id")));
     }
 }

--- a/src/main/java/com/realestate/backend/repository/LeadRequestRepository.java
+++ b/src/main/java/com/realestate/backend/repository/LeadRequestRepository.java
@@ -66,4 +66,13 @@ public interface LeadRequestRepository extends JpaRepository<PropertyLeadRequest
     long countByStatus(LeadStatus status);
 
     long countByAssignedAgentIdAndStatus(Long agentId, LeadStatus status);
+
+    @Modifying
+    @Query("""
+    UPDATE PropertyLeadRequest lr
+    SET lr.property.id = :propertyId,
+        lr.updatedAt = CURRENT_TIMESTAMP
+    WHERE lr.id = :id
+    """)
+    void updatePropertyId(@Param("id") Long id, @Param("propertyId") Long propertyId);
 }

--- a/src/main/java/com/realestate/backend/service/LeadService.java
+++ b/src/main/java/com/realestate/backend/service/LeadService.java
@@ -241,6 +241,15 @@ public class LeadService {
         return toResponse(findLead(id));
     }
 
+    @Transactional
+    public LeadResponse linkProperty(Long id, Long propertyId) {
+        assertIsAdminOrAgent();
+        PropertyLeadRequest lead = findLead(id);
+        leadRepo.updatePropertyId(id, propertyId);
+        log.info("Lead id={} u lidh me property id={}", id, propertyId);
+        return toResponse(findLead(id));
+    }
+
     // ── Helpers — pa ndryshim ─────────────────────────────────────────────────
 
     private PropertyLeadRequest findLead(Long id) {


### PR DESCRIPTION
Ky PR shton një endpoint të ri /{id}/property në backend, i cili mundëson ndryshimin e property_id për një Lead ekzistues.

Ky ndryshim lehtëson menaxhimin e Leads duke i dhënë mundësi sistemit (Admin/Agent) të përditësojë pronën e lidhur me një Lead në rastet kur është zgjedhur gabim ose ka ndryshime gjatë procesit të shitjes.
Poashtu kjo është bërë për ta bërë të mundur që në rastin kur Klienti krijon një Lead me të dhënat e pronës që dëshiron ta shesë/lëshojë me qira, atëherë property_id e asaj Lead fillimisht do të jetë null dhe pastaj kur Agjenti e konfirmon atë Lead, me anë të të dhënave pronësore të asaj Lead, automatikisht krijohet një Property e re dhe id e asaj Property i shtohet tek property_id e Leads ekzistuese.
Përfshin:

Endpoint të ri për update të property_id
Validime bazike për ekzistencën e Lead dhe Property
Përditësim në service layer dhe controller