### PR TITLE
Feat(Sales+Users): Agent listing ownership enforcement and agent name resolution

### DIFF
--- a/src/main/java/com/realestate/backend/config/SecurityConfig.java
+++ b/src/main/java/com/realestate/backend/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, "/api/properties/**").hasAnyRole("ADMIN", "AGENT")
 
                         // ── USERS — profili personal (të gjithë rolet) ────────────────
+                        .requestMatchers(HttpMethod.GET, "/api/users/agents/list").hasAnyRole("ADMIN","AGENT")
                         .requestMatchers(HttpMethod.GET,   "/api/users/me").hasAnyRole("ADMIN", "AGENT", "CLIENT")
                         .requestMatchers(HttpMethod.PUT,   "/api/users/me").hasAnyRole("ADMIN", "AGENT", "CLIENT")
                         .requestMatchers(HttpMethod.PATCH, "/api/users/me/password").hasAnyRole("ADMIN", "AGENT", "CLIENT")

--- a/src/main/java/com/realestate/backend/controller/SaleController.java
+++ b/src/main/java/com/realestate/backend/controller/SaleController.java
@@ -41,6 +41,16 @@ public class SaleController {
         return ResponseEntity.ok(saleService.getAllListings(PageRequest.of(page, size, sort)));
     }
 
+    @GetMapping("/listings/agent/me")
+    @Operation(summary = "Listings e agjentit tim")
+    @PreAuthorize("hasAnyRole('ADMIN','AGENT')")
+    public ResponseEntity<Page<SaleListingResponse>> getMyListings(
+            @RequestParam(defaultValue = "0")  int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(saleService.getMyListings(PageRequest.of(page, size)));
+    }
+
     @GetMapping("/listings/{id}")
     @Operation(summary = "Merr sale listing sipas ID")
     @PreAuthorize("hasAnyRole('ADMIN','AGENT','CLIENT')")

--- a/src/main/java/com/realestate/backend/controller/UserController.java
+++ b/src/main/java/com/realestate/backend/controller/UserController.java
@@ -48,6 +48,12 @@ public class UserController {
     public ResponseEntity<UserResponse> getById(@PathVariable Long id) {
         return ResponseEntity.ok(userService.getById(id));
     }
+    @GetMapping("/agents/list")
+    @Operation(summary = "Lista e agjentëve me emra (ADMIN/AGENT)")
+    @PreAuthorize("hasAnyRole('ADMIN','AGENT')")
+    public ResponseEntity<List<UserResponse>> getAgentsList() {
+        return ResponseEntity.ok(userService.getAgentsInTenant()); // ← metodë e re
+    }
 
     @PutMapping("/me")
     @Operation(summary = "Ndrysho profilin tim (emri, email)")

--- a/src/main/java/com/realestate/backend/service/SaleService.java
+++ b/src/main/java/com/realestate/backend/service/SaleService.java
@@ -355,6 +355,13 @@ public class SaleService {
         return toPaymentResponse(paymentRepo.save(payment));
     }
 
+    @Transactional(readOnly = true)
+    public Page<SaleListingResponse> getMyListings(Pageable pageable) {
+        assertIsAdminOrAgent();
+        return listingRepo.findByAgentIdAndDeletedAtIsNull(TenantContext.getUserId(), pageable)
+                .map(this::toListingResponse);
+    }
+
     // Helpers
 
     private SaleListing findActiveListing(Long id) {

--- a/src/main/java/com/realestate/backend/service/UserService.java
+++ b/src/main/java/com/realestate/backend/service/UserService.java
@@ -174,6 +174,22 @@ public class UserService {
         log.info("User id={} u fshi (soft delete) nga admin id={}", id, TenantContext.getUserId());
     }
 
+    @Transactional(readOnly = true)
+    public List<UserResponse> getAgentsInTenant() {
+        assertIsAdminOrAgent();  // ← lejon edhe AGENT
+        return userRepository.findAllByTenantId(TenantContext.getTenantId())
+                .stream()
+                .filter(u -> "AGENT".equalsIgnoreCase(u.getRole().name()))
+                .map(this::toResponse)
+                .toList();
+    }
+
+    // Shto helper nëse nuk ekziston
+    private void assertIsAdminOrAgent() {
+        if (!TenantContext.hasRole("ADMIN", "AGENT")) {
+            throw new ForbiddenException("Vetëm ADMIN ose AGENT mund të kryejë këtë veprim");
+        }
+    }
     // Helpers
 
     private User findUser(Long id) {


### PR DESCRIPTION
## Çfarë u bë

Ky PR implementon dy përmirësime kryesore të backend-it për modulin e Sales
dhe Users:

### 1. Endpoint i ri për listings e agjentit
- Shtohet `GET /api/sales/listings/agent/me` në `SaleController`
- Shtohet `getMyListings()` në `SaleService` që filtron bazuar në
  `TenantContext.getUserId()`
- Agjenti mund të shohë vetëm listings e veta nëpërmjet këtij endpoint-i

### 2. Emrat e agjentëve për listings
- Shtohet `getAgentsInTenant()` në `UserService` — kthen vetëm AGENT pa
  `assertIsAdmin()`, i aksesueshëm nga të dyja rolet
- Shtohet endpoint-i i ri: `GET /api/users/agents/list`

### 3. Fix SecurityConfig
- Rregullat specifike të `/api/users/agents/list` vendosen para rregullit të përgjithshëm `/api/users/**` për të parandaluar
  bllokimin 403

## Si të testohet
1. Kycu si AGENT → hyr te `/agent/sales` → listings e veta duhet të shfaqen
2. Kliko "All Listings" → duhet të shfaqen emrat e agjentëve
3. Kontrollo Swagger: `GET /api/users/agents/list` me token AGENT → duhet 200
4. Kontrollo që `GET /api/users` me token AGENT → duhet ende 403