### PR TITLE
Feat/rental commission backend

### DIFF
--- a/src/main/java/com/realestate/backend/dto/rental/PaymentDtos.java
+++ b/src/main/java/com/realestate/backend/dto/rental/PaymentDtos.java
@@ -26,7 +26,7 @@ public class PaymentDtos {
 
             @Size(max = 10) String currency,
 
-            @Schema(allowableValues = {"RENT","DEPOSIT","LATE_FEE","MAINTENANCE"})
+            @Schema(allowableValues = {"RENT","DEPOSIT","LATE_FEE","MAINTENANCE","AGENT_COMMISSION","CLIENT_BONUS"})
             @JsonProperty("payment_type")
             PaymentType paymentType,
 
@@ -36,6 +36,10 @@ public class PaymentDtos {
 
             @JsonProperty("payment_method")
             String paymentMethod,
+
+            // recipient_id — opcionale, nëse null → kompania
+            @JsonProperty("recipient_id")
+            Long recipientId,
 
             String notes
     ) {}
@@ -66,17 +70,22 @@ public class PaymentDtos {
 
     public record PaymentResponse(
             Long id,
-            @JsonProperty("contract_id")     Long contractId,
+            @JsonProperty("contract_id")      Long contractId,
             BigDecimal amount,
             String currency,
-            @JsonProperty("payment_type")    PaymentType paymentType,
-            @JsonProperty("due_date")        LocalDate dueDate,
-            @JsonProperty("paid_date")       LocalDate paidDate,
-            @JsonProperty("payment_method")  String paymentMethod,
-            @JsonProperty("transaction_ref") String transactionRef,
+            @JsonProperty("payment_type")     PaymentType paymentType,
+            @JsonProperty("due_date")         LocalDate dueDate,
+            @JsonProperty("paid_date")        LocalDate paidDate,
+            @JsonProperty("payment_method")   String paymentMethod,
+            @JsonProperty("transaction_ref")  String transactionRef,
+            // ── Recipient — identik me SalePaymentResponse ──
+            @JsonProperty("recipient_id")     Long recipientId,
+            @JsonProperty("recipient_name")   String recipientName,
+            @JsonProperty("recipient_type")   String recipientType,
+            // ────────────────────────────────────────────────
             PaymentStatus status,
             String notes,
-            @JsonProperty("created_at")      LocalDateTime createdAt
+            @JsonProperty("created_at")       LocalDateTime createdAt
     ) {}
 
     // ── SUMMARY (stats dashboard) ─────────────────────────────

--- a/src/main/java/com/realestate/backend/entity/enums/PaymentType.java
+++ b/src/main/java/com/realestate/backend/entity/enums/PaymentType.java
@@ -4,5 +4,8 @@ public enum PaymentType {
     RENT,
     DEPOSIT,
     LATE_FEE,
-    MAINTENANCE
+    MAINTENANCE,
+    AGENT_COMMISSION,
+    CLIENT_BONUS,
+    COMMISSION
 }

--- a/src/main/java/com/realestate/backend/repository/LeadRequestRepository.java
+++ b/src/main/java/com/realestate/backend/repository/LeadRequestRepository.java
@@ -74,5 +74,13 @@ public interface LeadRequestRepository extends JpaRepository<PropertyLeadRequest
         lr.updatedAt = CURRENT_TIMESTAMP
     WHERE lr.id = :id
     """)
+
     void updatePropertyId(@Param("id") Long id, @Param("propertyId") Long propertyId);
+    @Query("""
+        SELECT plr FROM PropertyLeadRequest plr
+        WHERE plr.property.id = :propertyId
+          AND plr.status IN ('DONE', 'IN_PROGRESS')
+        ORDER BY plr.createdAt DESC
+    """)
+    List<PropertyLeadRequest> findByPropertyIdOrdered(@Param("propertyId") Long propertyId);
 }

--- a/src/main/java/com/realestate/backend/repository/PaymentRepository.java
+++ b/src/main/java/com/realestate/backend/repository/PaymentRepository.java
@@ -15,24 +15,54 @@ import java.util.List;
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
-    // Pagesat sipas kontratës
-    List<Payment> findByContract_IdOrderByDueDateAsc(Long contractId);
-
-    // Pagesat sipas statusit
-    Page<Payment> findByStatusOrderByDueDateAsc(PaymentStatus status, Pageable pageable);
-
-    // Pagesat e vonuara (PENDING me due_date të kaluar)
+    // Pagesat sipas kontratës — LEFT JOIN FETCH recipient
+    // pa fetch, Hibernate lazy-load e kthen null kur sesioni mbyllet
     @Query("""
         SELECT p FROM Payment p
+        LEFT JOIN FETCH p.recipient
+        WHERE p.contract.id = :contractId
+        ORDER BY p.dueDate ASC
+    """)
+    List<Payment> findByContract_IdOrderByDueDateAsc(@Param("contractId") Long contractId);
+
+    // Pagesat sipas statusit — LEFT JOIN FETCH recipient
+    // Page<> nuk lejon JOIN FETCH direkt — duhet countQuery i veçantë
+    @Query(
+            value = """
+            SELECT p FROM Payment p
+            LEFT JOIN FETCH p.recipient
+            WHERE p.status = :status
+            ORDER BY p.dueDate ASC
+        """,
+            countQuery = """
+            SELECT COUNT(p) FROM Payment p
+            WHERE p.status = :status
+        """
+    )
+    Page<Payment> findByStatusOrderByDueDateAsc(
+            @Param("status") PaymentStatus status, Pageable pageable);
+
+    // Pagesat e vonuara — LEFT JOIN FETCH recipient
+    @Query("""
+        SELECT p FROM Payment p
+        LEFT JOIN FETCH p.recipient
         WHERE p.status = com.realestate.backend.entity.enums.PaymentStatus.PENDING
           AND p.dueDate < :today
         ORDER BY p.dueDate ASC
     """)
     List<Payment> findOverduePayments(@Param("today") LocalDate today);
 
-    // Pagesat e kontratës sipas statusit
+    // Pagesat e kontratës sipas statusit — LEFT JOIN FETCH recipient
+    @Query("""
+        SELECT p FROM Payment p
+        LEFT JOIN FETCH p.recipient
+        WHERE p.contract.id = :contractId
+          AND p.status = :status
+        ORDER BY p.dueDate ASC
+    """)
     List<Payment> findByContract_IdAndStatusOrderByDueDateAsc(
-            Long contractId, PaymentStatus status);
+            @Param("contractId") Long contractId,
+            @Param("status") PaymentStatus status);
 
     // Totali i të ardhurave të paguara
     @Query("""
@@ -51,9 +81,10 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     """)
     BigDecimal totalPaidByContract(@Param("contractId") Long contractId);
 
-    // Pagesat e muajit aktual
+    // Pagesat e muajit aktual — LEFT JOIN FETCH recipient
     @Query("""
         SELECT p FROM Payment p
+        LEFT JOIN FETCH p.recipient
         WHERE p.dueDate BETWEEN :from AND :to
         ORDER BY p.dueDate ASC
     """)

--- a/src/main/java/com/realestate/backend/service/LeaseContractService.java
+++ b/src/main/java/com/realestate/backend/service/LeaseContractService.java
@@ -1,17 +1,25 @@
 package com.realestate.backend.service;
 
 import com.realestate.backend.dto.rental.LeaseContractDtos.*;
+import com.realestate.backend.entity.User;
 import com.realestate.backend.entity.enums.LeaseStatus;
+import com.realestate.backend.entity.enums.PaymentStatus;
+import com.realestate.backend.entity.enums.PaymentType;
+import com.realestate.backend.entity.lead.PropertyLeadRequest;
 import com.realestate.backend.entity.property.Property;
 import com.realestate.backend.entity.rental.LeaseContract;
+import com.realestate.backend.entity.rental.Payment;
 import com.realestate.backend.entity.rental.RentalListing;
 import com.realestate.backend.exception.ConflictException;
 import com.realestate.backend.exception.ForbiddenException;
 import com.realestate.backend.exception.ResourceNotFoundException;
 import com.realestate.backend.multitenancy.TenantContext;
 import com.realestate.backend.repository.LeaseContractRepository;
+import com.realestate.backend.repository.LeadRequestRepository;
+import com.realestate.backend.repository.PaymentRepository;
 import com.realestate.backend.repository.PropertyRepository;
 import com.realestate.backend.repository.RentalListingRepository;
+import com.realestate.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
@@ -30,8 +38,14 @@ public class LeaseContractService {
     private final LeaseContractRepository contractRepo;
     private final PropertyRepository      propertyRepo;
     private final RentalListingRepository listingRepo;
+    private final PaymentRepository       paymentRepo;
+    private final UserRepository          userRepo;
+    private final LeadRequestRepository   leadRequestRepo;
 
     private static final List<String> VALID_CURRENCIES = List.of("EUR","USD","GBP","CHF","ALL","MKD");
+
+    // Komisioni = 3% e 1 muaj qiraje
+    private static final BigDecimal COMMISSION_RATE = new BigDecimal("0.03");
 
     // ── Listim ───────────────────────────────────────────────────
     @Transactional(readOnly = true)
@@ -142,8 +156,16 @@ public class LeaseContractService {
     @Transactional
     public LeaseContractResponse updateStatus(Long id, LeaseStatusRequest req) {
         assertIsAdminOrAgent();
-        findContract(id);
+        LeaseContract contract = findContract(id);
         contractRepo.updateStatus(id, req.status());
+
+        // Kur kontrata aktivizohet → krijo pagesat e komisionit
+        if (req.status() == LeaseStatus.ACTIVE
+                && contract.getStatus() == LeaseStatus.PENDING_SIGNATURE) {
+            LeaseContract fresh = findContract(id);
+            createRentalCommissionPayments(fresh);
+        }
+
         log.info("LeaseContract id={} status → {}", id, req.status());
         return toResponse(findContract(id));
     }
@@ -151,6 +173,117 @@ public class LeaseContractService {
     @Transactional(readOnly = true)
     public long countActive() {
         return contractRepo.countByStatus(LeaseStatus.ACTIVE);
+    }
+
+    // ════════════════════════════════════════════════════════════
+    // KOMISIONI — identik me Sales, aktivizohet kur ACTIVE
+    // Baza: 1 muaj qira × 3% = komisioni total
+    // ════════════════════════════════════════════════════════════
+
+    private void createRentalCommissionPayments(LeaseContract contract) {
+        // Nëse rent është null ose zero, mos krijo komisione
+        if (contract.getRent() == null
+                || contract.getRent().compareTo(BigDecimal.ZERO) == 0) {
+            log.warn("LeaseContract id={} ka rent=0, komisioni nuk u krijua", contract.getId());
+            return;
+        }
+
+        BigDecimal rent            = contract.getRent();
+        BigDecimal commissionTotal = rent.multiply(COMMISSION_RATE);
+        BigDecimal ownerAmount     = rent.multiply(new BigDecimal("0.97"));
+        String     currency        = contract.getCurrency();
+
+        // Kontrollo nëse prona erdhi nga lead me status DONE
+        // (pronari është klienti që solli pronën — njësoj si Sales)
+        Long ownerClientId = leadRequestRepo
+                .findByPropertyIdOrdered(contract.getProperty().getId())
+                .stream()
+                .filter(l -> l.getStatus().name().equals("DONE"))
+                .findFirst()
+                .map(PropertyLeadRequest::getClientId)
+                .orElse(null);
+
+        boolean isClientOwnedProperty = ownerClientId != null;
+
+        if (isClientOwnedProperty) {
+            // ══════════════════════════════════════════════════
+            // SKENARI 1 — Pronë e klientit (erdhi nga lead DONE)
+            // ══════════════════════════════════════════════════
+            log.info("Rental komisioni — Skenari 1: pronë e klientit id={}, contract={}",
+                    ownerClientId, contract.getId());
+
+            User owner = userRepo.findById(ownerClientId)
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "Pronari nuk u gjet: " + ownerClientId));
+
+            // 1. RENT (97%) → pronari
+            savePayment(contract, ownerAmount, currency, PaymentType.RENT, owner);
+
+            // 2. COMMISSION (50% e komisionit) → kompania (recipient=null)
+            savePayment(contract,
+                    commissionTotal.multiply(new BigDecimal("0.50")),
+                    currency, PaymentType.COMMISSION, null);
+
+            // 3. AGENT_COMMISSION (40% e komisionit) → agjenti
+            userRepo.findById(contract.getAgentId()).ifPresent(agent ->
+                    savePayment(contract,
+                            commissionTotal.multiply(new BigDecimal("0.40")),
+                            currency, PaymentType.AGENT_COMMISSION, agent)
+            );
+
+            // 4. CLIENT_BONUS (10% e komisionit) → pronari
+            savePayment(contract,
+                    commissionTotal.multiply(new BigDecimal("0.10")),
+                    currency, PaymentType.CLIENT_BONUS, owner);
+
+            log.info("Skenari 1 rental payments: RENT={} COMMISSION={} AGENT={} BONUS={}",
+                    ownerAmount,
+                    commissionTotal.multiply(new BigDecimal("0.50")),
+                    commissionTotal.multiply(new BigDecimal("0.40")),
+                    commissionTotal.multiply(new BigDecimal("0.10")));
+
+        } else {
+            // ══════════════════════════════════════════════════
+            // SKENARI 2 — Pronë e kompanisë (pa lead DONE)
+            // ══════════════════════════════════════════════════
+            log.info("Rental komisioni — Skenari 2: pronë e kompanisë, contract={}",
+                    contract.getId());
+
+            // 1. RENT (97%) → kompania (prona është e kompanisë)
+            savePayment(contract, ownerAmount, currency, PaymentType.RENT, null);
+
+            // 2. COMMISSION (60% e komisionit) → kompania
+            savePayment(contract,
+                    commissionTotal.multiply(new BigDecimal("0.60")),
+                    currency, PaymentType.COMMISSION, null);
+
+            // 3. AGENT_COMMISSION (40% e komisionit) → agjenti
+            userRepo.findById(contract.getAgentId()).ifPresent(agent ->
+                    savePayment(contract,
+                            commissionTotal.multiply(new BigDecimal("0.40")),
+                            currency, PaymentType.AGENT_COMMISSION, agent)
+            );
+
+            log.info("Skenari 2 rental payments: RENT={} COMMISSION={} AGENT={}",
+                    ownerAmount,
+                    commissionTotal.multiply(new BigDecimal("0.60")),
+                    commissionTotal.multiply(new BigDecimal("0.40")));
+        }
+    }
+
+    // Helper i brendshëm — krijo dhe ruaj Payment
+    private void savePayment(LeaseContract contract, BigDecimal amount,
+                             String currency, PaymentType type, User recipient) {
+        Payment payment = Payment.builder()
+                .contract(contract)
+                .amount(amount)
+                .currency(currency)
+                .paymentType(type)
+                .dueDate(contract.getStartDate())
+                .recipient(recipient)
+                .status(PaymentStatus.PENDING)
+                .build();
+        paymentRepo.save(payment);
     }
 
     // ════════════════════════════════════════════════════════════
@@ -190,7 +323,6 @@ public class LeaseContractService {
     }
 
     private void validateUpdate(LeaseContractUpdateRequest req, LeaseContract existing) {
-        // Valido datat nëse ndryshojnë
         LocalDate start = req.startDate() != null ? req.startDate() : existing.getStartDate();
         LocalDate end   = req.endDate()   != null ? req.endDate()   : existing.getEndDate();
         if (start != null && end != null && !end.isAfter(start))

--- a/src/main/java/com/realestate/backend/service/PaymentService.java
+++ b/src/main/java/com/realestate/backend/service/PaymentService.java
@@ -1,6 +1,7 @@
 package com.realestate.backend.service;
 
 import com.realestate.backend.dto.rental.PaymentDtos.*;
+import com.realestate.backend.entity.User;
 import com.realestate.backend.entity.enums.PaymentStatus;
 import com.realestate.backend.entity.enums.PaymentType;
 import com.realestate.backend.entity.rental.LeaseContract;
@@ -11,6 +12,7 @@ import com.realestate.backend.exception.ResourceNotFoundException;
 import com.realestate.backend.multitenancy.TenantContext;
 import com.realestate.backend.repository.LeaseContractRepository;
 import com.realestate.backend.repository.PaymentRepository;
+import com.realestate.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
@@ -28,6 +30,7 @@ public class PaymentService {
 
     private final PaymentRepository       paymentRepo;
     private final LeaseContractRepository contractRepo;
+    private final UserRepository          userRepo;
 
     private static final List<String> VALID_CURRENCIES = List.of("EUR","USD","GBP","CHF","ALL","MKD");
     private static final List<String> VALID_PAY_TYPES  = List.of("RENT","DEPOSIT","LATE_FEE","MAINTENANCE");
@@ -35,7 +38,6 @@ public class PaymentService {
     // ── Queries ───────────────────────────────────────────────────
     @Transactional(readOnly = true)
     public List<PaymentResponse> getByContract(Long contractId) {
-      //assertIsAdminOrAgent();
         if (contractId == null || contractId <= 0)
             throw new IllegalArgumentException("contractId invalid");
         return paymentRepo.findByContract_IdOrderByDueDateAsc(contractId)
@@ -71,6 +73,13 @@ public class PaymentService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Kontrata nuk u gjet: " + req.contractId()));
 
+        User recipient = null;
+        if (req.recipientId() != null) {
+            recipient = userRepo.findById(req.recipientId())
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            "User nuk u gjet: " + req.recipientId()));
+        }
+
         Payment payment = Payment.builder()
                 .contract(contract)
                 .amount(req.amount())
@@ -78,13 +87,15 @@ public class PaymentService {
                 .paymentType(req.paymentType())
                 .dueDate(req.dueDate())
                 .paymentMethod(req.paymentMethod())
+                .recipient(recipient)
                 .notes(req.notes())
                 .status(PaymentStatus.PENDING)
                 .build();
 
         Payment saved = paymentRepo.save(payment);
-        log.info("Payment created: id={}, contract={}, amount={}",
-                saved.getId(), req.contractId(), req.amount());
+        log.info("Payment created: id={}, contract={}, amount={}, recipient={}",
+                saved.getId(), req.contractId(), req.amount(),
+                recipient != null ? recipient.getId() : "COMPANY");
         return toResponse(saved);
     }
 
@@ -123,7 +134,7 @@ public class PaymentService {
         return toResponse(paymentRepo.save(payment));
     }
 
-    // ── Mark overdue (background job) ────────────────────────────
+    // ── Mark overdue (background job) ─────────────────────────────
     @Transactional
     public int markOverduePayments() {
         List<Payment> overdue = paymentRepo.findOverduePayments(LocalDate.now());
@@ -136,7 +147,6 @@ public class PaymentService {
     // ── Summary ───────────────────────────────────────────────────
     @Transactional(readOnly = true)
     public PaymentSummaryResponse getSummaryByContract(Long contractId) {
-        //assertIsAdminOrAgent();
         List<PaymentResponse> payments = paymentRepo
                 .findByContract_IdOrderByDueDateAsc(contractId)
                 .stream().map(this::toResponse).toList();
@@ -159,6 +169,10 @@ public class PaymentService {
         assertIsAdminOrAgent();
         return paymentRepo.totalRevenue();
     }
+
+    // ════════════════════════════════════════════════════════════
+    // VALIDATION
+    // ════════════════════════════════════════════════════════════
 
     private void validateCreate(PaymentCreateRequest req) {
         if (req.contractId() == null || req.contractId() <= 0)
@@ -184,6 +198,10 @@ public class PaymentService {
             throw new IllegalArgumentException("paymentMethod max 50 karaktere");
     }
 
+    // ════════════════════════════════════════════════════════════
+    // HELPERS & MAPPERS
+    // ════════════════════════════════════════════════════════════
+
     private Payment findPayment(Long id) {
         return paymentRepo.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Pagesa nuk u gjet: " + id));
@@ -194,14 +212,34 @@ public class PaymentService {
             throw new ForbiddenException("Vetëm ADMIN ose AGENT mund të kryejë këtë veprim");
     }
 
+    // ── Mapper — tani me recipient_id, recipient_name, recipient_type ──
     private PaymentResponse toResponse(Payment p) {
+        Long   recipientId   = null;
+        String recipientName = null;
+        String recipientType = "COMPANY"; // default kur NULL — njësoj si Sales
+
+        if (p.getRecipient() != null) {
+            recipientId   = p.getRecipient().getId();
+            recipientName = p.getRecipient().getFullName();
+            recipientType = p.getRecipient().getRole().name(); // "AGENT" ose "CLIENT"
+        }
+
         return new PaymentResponse(
                 p.getId(),
                 p.getContract() != null ? p.getContract().getId() : null,
-                p.getAmount(), p.getCurrency(),
-                p.getPaymentType(), p.getDueDate(), p.getPaidDate(),
-                p.getPaymentMethod(), p.getTransactionRef(),
-                p.getStatus(), p.getNotes(), p.getCreatedAt()
+                p.getAmount(),
+                p.getCurrency(),
+                p.getPaymentType(),
+                p.getDueDate(),
+                p.getPaidDate(),
+                p.getPaymentMethod(),
+                p.getTransactionRef(),
+                recipientId,
+                recipientName,
+                recipientType,
+                p.getStatus(),
+                p.getNotes(),
+                p.getCreatedAt()
         );
     }
 }


### PR DESCRIPTION

Ky PR implementon logjikën e plotë të komisioneve për kontratat e qirasë, identike me sistemin ekzistues të shitjeve. Kur një kontratë kalon nga `PENDING_SIGNATURE` në `ACTIVE`, sistemi krijon automatikisht pagesat e komisionit bazuar në origjinën e pronës.

---

### Logjika e implementuar

**Skenari 1 — Pronë e klientit (lead me status DONE):**
- `RENT` 97% → pronari (klienti që solli pronën)
- `COMMISSION` 50% e komisionit → kompania
- `AGENT_COMMISSION` 40% e komisionit → agjenti
- `CLIENT_BONUS` 10% e komisionit → pronari (bonus shtesë)

**Skenari 2 — Pronë e kompanisë (pa lead DONE):**
- `RENT` 97% → kompania
- `COMMISSION` 60% e komisionit → kompania
- `AGENT_COMMISSION` 40% e komisionit → agjenti

Baza e komisionit: `3% × qiraja mujore`

---

### Ndryshimet sipas fajllit

**`PaymentDtos.java`**
Shtohen tre fusha të reja në `PaymentResponse`: `recipient_id`, `recipient_name`, `recipient_type`. Shtohet `recipient_id` në `PaymentCreateRequest` për krijim manual të pagesave me recipient specifik.

**`PaymentType.java`**
Shtohen dy vlera të reja në enum: `AGENT_COMMISSION` dhe `CLIENT_BONUS`, të nevojshme për kategorizimin e pagesave të komisionit.

**`PaymentRepository.java`**
Shtohet `LEFT JOIN FETCH p.recipient` në të gjitha queries që kthejnë entitete `Payment`. Kjo zgjidh problemin e Hibernate lazy loading — pa fetch, `recipient` vinte `null` edhe kur kishte vlerë në DB.

**`PaymentService.java`**
Injektohet `UserRepository`. Metoda `toResponse()` mappon tani `recipient_id`, `recipient_name` dhe `recipient_type` — para këtij ndryshimi këto fusha nuk kthenin asgjë në API edhe pse ekzistonin në DTO.

**`LeaseContractService.java`**
Injektohen `PaymentRepository`, `UserRepository`, `LeadRequestRepository`. Metoda `updateStatus()` thërret `createRentalCommissionPayments()` kur statusi kalon `PENDING_SIGNATURE → ACTIVE`. Logjika e ndarjes së komisionit është identike me `SaleService`.

**`LeadRequestRepository.java`**
Shtohet query `findByPropertyIdOrdered()` që kthen lead-et me status `DONE` ose `IN_PROGRESS` për një pronë të caktuar, e përdorur nga `LeaseContractService` për të përcaktuar skenarin e komisionit.

---

### Lidhja me PR-të e tjera
Ky PR kërkon `feat/rental-commission-frontend` për të shfaqur pagesat e komisionit dhe progress bar-in në UI.

closes #47