### PR TITLE
Fix AGENT access for marking sale payments as paid

### DIFF
--- a/src/main/resources/db/migration/public/V14__fix_agent_sale_payment_permissions.sql
+++ b/src/main/resources/db/migration/public/V14__fix_agent_sale_payment_permissions.sql
@@ -1,0 +1,10 @@
+INSERT INTO public.permissions (name, http_method, api_path, description)
+VALUES ('sale.payment.pay', 'PATCH', '/api/sales/payments/*/pay', 'Mark sale payment as paid')
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM public.roles r
+JOIN public.permissions p ON p.name = 'sale.payment.pay'
+WHERE r.name = 'AGENT'
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Ky PR rregullon problemin e autorizimit ku përdoruesit me rolin AGENT nuk mund të bënin mark paid për sale payments.

Ndryshimet:
- U shtua permission-i `sale.payment.pay`
- U konfigurua:
  - HTTP Method: PATCH
  - API Path: `/api/sales/payments/*/pay`
- Permission-i iu asignua rolit AGENT
- U përdor `ON CONFLICT DO NOTHING` për të shmangur inserte duplicate

Arsyeja:
Më parë AGENT merrte gabimin:

`Access denied. You do not have permission for PATCH /api/sales/payments/1/pay`

Close #80 