### PR TITLE
Add unit tests for AI, scheduler and tenant services

### DIFF
--- a/src/test/java/com/realestate/backend/service/AiServiceTest.java
+++ b/src/test/java/com/realestate/backend/service/AiServiceTest.java
@@ -1,0 +1,347 @@
+package com.realestate.backend.service;
+
+import com.realestate.backend.dto.ai.AiDtos.*;
+import com.realestate.backend.entity.enums.PaymentStatus;
+import com.realestate.backend.entity.enums.PropertyStatus;
+import com.realestate.backend.entity.rental.LeaseContract;
+import com.realestate.backend.entity.rental.Payment;
+import com.realestate.backend.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AiServiceTest {
+
+    @Mock private PropertyRepository      propertyRepo;
+    @Mock private PaymentRepository       paymentRepo;
+    @Mock private LeaseContractRepository contractRepo;
+
+    @InjectMocks
+    private AiService aiService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(aiService, "apiKey", "placeholder");
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // 1. generateDescription
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("generateDescription - kthen title dhe description nga mock")
+    void generateDescription_returnsMockResponse() {
+        // String type, Integer bedrooms, Integer bathrooms,
+        // String areaSqm, Integer floor, Integer yearBuilt,
+        // String city, String features, String price
+        PropertyDescriptionRequest req = new PropertyDescriptionRequest(
+                "APARTMENT", 2, 1,
+                "85", 3, 2015,
+                "Prishtinë", "parking, balcony", "95000"
+        );
+
+        PropertyDescriptionResponse resp = aiService.generateDescription(req);
+
+        assertThat(resp).isNotNull();
+        assertThat(resp.title()).isNotBlank();
+        assertThat(resp.description()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("generateDescription - title dhe description nuk janë null")
+    void generateDescription_titleAndDescriptionNotNull() {
+        PropertyDescriptionRequest req = new PropertyDescriptionRequest(
+                "VILLA", 4, 2,
+                "200", 1, 2020,
+                "Tiranë", "pool, garden", "250000"
+        );
+
+        PropertyDescriptionResponse resp = aiService.generateDescription(req);
+
+        assertThat(resp.title()).isNotNull();
+        assertThat(resp.description()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("generateDescription - nuk thirret asnjë repository")
+    void generateDescription_doesNotCallRepositories() {
+        PropertyDescriptionRequest req = new PropertyDescriptionRequest(
+                "HOUSE", 3, 2,
+                "120", 2, 2018,
+                "Gjilan", "parking", "150000"
+        );
+
+        aiService.generateDescription(req);
+
+        verifyNoInteractions(propertyRepo, paymentRepo, contractRepo);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // 2. estimatePrice
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("estimatePrice - kthen çmim pozitiv dhe confidence")
+    void estimatePrice_returnsPositiveValues() {
+        when(propertyRepo.countByStatus(PropertyStatus.AVAILABLE)).thenReturn(42L);
+
+        // String type, String areaSqm, Integer bedrooms,
+        // String city, Integer floor, Integer totalFloors,
+        // Integer yearBuilt, String listingType
+        PriceEstimateRequest req = new PriceEstimateRequest(
+                "APARTMENT", "85", 2,
+                "Prishtinë", 3, 5,
+                2015, "SALE"
+        );
+
+        PriceEstimateResponse resp = aiService.estimatePrice(req);
+
+        assertThat(resp).isNotNull();
+        assertThat(resp.estimatedPrice()).isGreaterThanOrEqualTo(0);
+        assertThat(resp.pricePerSqm()).isGreaterThanOrEqualTo(0);
+        assertThat(resp.confidence()).isNotBlank();
+        assertThat(resp.reasoning()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("estimatePrice - thirr propertyRepo.countByStatus(AVAILABLE)")
+    void estimatePrice_callsPropertyRepo() {
+        when(propertyRepo.countByStatus(PropertyStatus.AVAILABLE)).thenReturn(10L);
+
+        PriceEstimateRequest req = new PriceEstimateRequest(
+                "HOUSE", "120", 3,
+                "Gjilan", 1, 2,
+                2018, "SALE"
+        );
+
+        aiService.estimatePrice(req);
+
+        verify(propertyRepo, times(1)).countByStatus(PropertyStatus.AVAILABLE);
+    }
+
+    @Test
+    @DisplayName("estimatePrice - nuk thirret paymentRepo apo contractRepo")
+    void estimatePrice_doesNotCallOtherRepos() {
+        when(propertyRepo.countByStatus(PropertyStatus.AVAILABLE)).thenReturn(5L);
+
+        PriceEstimateRequest req = new PriceEstimateRequest(
+                "COMMERCIAL", "300", 0,
+                "Ferizaj", 0, 1,
+                2019, "RENT"
+        );
+
+        aiService.estimatePrice(req);
+
+        verifyNoInteractions(paymentRepo, contractRepo);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // 3. chat — mock mode (placeholder key)
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("chat - mesazh për blerje kthen udhëzim për sale listings")
+    void chat_buyKeyword_returnsSaleListingsAdvice() {
+        ChatRequest req = new ChatRequest("I want to buy a house", null);
+
+        ChatResponse resp = aiService.chat(req);
+
+        assertThat(resp).isNotNull();
+        assertThat(resp.message()).isNotBlank();
+        assertThat(resp.role()).isEqualTo("assistant");
+        assertThat(resp.message()).containsIgnoringCase("sale listings");
+    }
+
+    @Test
+    @DisplayName("chat - mesazh për qira kthen udhëzim për rentals")
+    void chat_rentKeyword_returnsRentalAdvice() {
+        ChatRequest req = new ChatRequest("rent apartment", null);
+
+        ChatResponse resp = aiService.chat(req);
+
+        assertThat(resp.message()).containsIgnoringCase("rental");
+    }
+
+    @Test
+    @DisplayName("chat - mesazh për çmim kthen udhëzim budget")
+    void chat_priceKeyword_returnsBudgetAdvice() {
+        ChatRequest req = new ChatRequest("affordable cheap budget", null);
+
+        ChatResponse resp = aiService.chat(req);
+
+        assertThat(resp.message()).containsIgnoringCase("budget");
+    }
+
+    @Test
+    @DisplayName("chat - mesazh i panjohur kthen default response")
+    void chat_unknownMessage_returnsDefaultResponse() {
+        ChatRequest req = new ChatRequest("xyzabc123", null);
+
+        ChatResponse resp = aiService.chat(req);
+
+        assertThat(resp.message()).isNotBlank();
+        assertThat(resp.role()).isEqualTo("assistant");
+    }
+
+    @Test
+    @DisplayName("chat - mesazh përshëndetje kthen welcome")
+    void chat_greetingMessage_returnsWelcome() {
+        ChatRequest req = new ChatRequest("hello", null);
+
+        ChatResponse resp = aiService.chat(req);
+
+        assertThat(resp.message()).containsIgnoringCase("welcome");
+    }
+
+    @Test
+    @DisplayName("chat - nuk thirret asnjë repository")
+    void chat_doesNotCallAnyRepository() {
+        ChatRequest req = new ChatRequest("looking for a property", null);
+
+        aiService.chat(req);
+
+        verifyNoInteractions(propertyRepo, paymentRepo, contractRepo);
+    }
+
+    @Test
+    @DisplayName("chat - me historik → nuk hedh exception")
+    void chat_withHistory_doesNotThrow() {
+        List<ChatMessage> history = List.of(
+                new ChatMessage("user",      "I need help"),
+                new ChatMessage("assistant", "How can I assist?")
+        );
+        ChatRequest req = new ChatRequest("find me a house", history);
+
+        assertThatCode(() -> aiService.chat(req)).doesNotThrowAnyException();
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // 4. summarizeContract
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("summarizeContract - kthen të gjitha fushat e nevojshme")
+    void summarizeContract_returnsAllFields() {
+        // Long contractId, Long propertyId, Long clientId, Long agentId,
+        // String startDate, String endDate,
+        // String rent, String deposit, String status
+        ContractSummaryRequest req = new ContractSummaryRequest(
+                1L, 10L, 5L, 3L,
+                "2024-01-01", "2025-01-01",
+                "500", "1000", "ACTIVE"
+        );
+
+        ContractSummaryResponse resp = aiService.summarizeContract(req);
+
+        assertThat(resp).isNotNull();
+        assertThat(resp.summary()).isNotBlank();
+        assertThat(resp.keyDates()).isNotBlank();
+        assertThat(resp.financialObligations()).isNotBlank();
+        assertThat(resp.risks()).isNotBlank();
+        assertThat(resp.statusNote()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("summarizeContract - nuk thirret asnjë repository")
+    void summarizeContract_doesNotCallRepositories() {
+        ContractSummaryRequest req = new ContractSummaryRequest(
+                2L, 20L, 8L, 4L,
+                "2024-06-01", "2025-06-01",
+                "700", "1400", "ACTIVE"
+        );
+
+        aiService.summarizeContract(req);
+
+        verifyNoInteractions(propertyRepo, paymentRepo, contractRepo);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // 5. detectPaymentRisk
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("detectPaymentRisk - klient pa kontrata kthen response të vlefshme")
+    void detectPaymentRisk_noContracts_returnsValidResponse() {
+        Long clientId = 1L;
+        when(contractRepo.findActiveByClient(clientId)).thenReturn(List.of());
+
+        PaymentRiskResponse resp = aiService.detectPaymentRisk(clientId);
+
+        assertThat(resp).isNotNull();
+        assertThat(resp.clientId()).isEqualTo(clientId);
+        assertThat(resp.riskScore()).isGreaterThanOrEqualTo(1);
+        assertThat(resp.riskLevel()).isNotBlank();
+        assertThat(resp.totalPayments()).isEqualTo(0);
+        assertThat(resp.overduePayments()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("detectPaymentRisk - me pagesa OVERDUE thirr paymentRepo saktë")
+    void detectPaymentRisk_withOverduePayments_callsPaymentRepo() {
+        Long clientId = 2L;
+
+        LeaseContract contract = new LeaseContract();
+        contract.setId(10L);
+
+        Payment overduePayment = new Payment();
+        overduePayment.setStatus(PaymentStatus.OVERDUE);
+
+        Payment paidPayment = new Payment();
+        paidPayment.setStatus(PaymentStatus.PAID);
+
+        when(contractRepo.findActiveByClient(clientId)).thenReturn(List.of(contract));
+        when(paymentRepo.findByContract_IdOrderByDueDateAsc(10L))
+                .thenReturn(List.of(overduePayment, paidPayment));
+
+        PaymentRiskResponse resp = aiService.detectPaymentRisk(clientId);
+
+        assertThat(resp.clientId()).isEqualTo(clientId);
+        assertThat(resp.totalPayments()).isEqualTo(2);
+        assertThat(resp.overduePayments()).isEqualTo(1);
+        verify(paymentRepo).findByContract_IdOrderByDueDateAsc(10L);
+    }
+
+    @Test
+    @DisplayName("detectPaymentRisk - të gjitha pagesat PAID → overdue = 0")
+    void detectPaymentRisk_allPaid_overdueIsZero() {
+        Long clientId = 3L;
+
+        LeaseContract contract = new LeaseContract();
+        contract.setId(20L);
+
+        Payment p1 = new Payment(); p1.setStatus(PaymentStatus.PAID);
+        Payment p2 = new Payment(); p2.setStatus(PaymentStatus.PAID);
+        Payment p3 = new Payment(); p3.setStatus(PaymentStatus.PAID);
+
+        when(contractRepo.findActiveByClient(clientId)).thenReturn(List.of(contract));
+        when(paymentRepo.findByContract_IdOrderByDueDateAsc(20L))
+                .thenReturn(List.of(p1, p2, p3));
+
+        PaymentRiskResponse resp = aiService.detectPaymentRisk(clientId);
+
+        assertThat(resp.overduePayments()).isEqualTo(0);
+        assertThat(resp.totalPayments()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("detectPaymentRisk - thirr contractRepo.findActiveByClient me ID të saktë")
+    void detectPaymentRisk_callsContractRepoWithCorrectId() {
+        Long clientId = 99L;
+        when(contractRepo.findActiveByClient(clientId)).thenReturn(List.of());
+
+        aiService.detectPaymentRisk(clientId);
+
+        verify(contractRepo).findActiveByClient(99L);
+    }
+}

--- a/src/test/java/com/realestate/backend/service/SchedulerServiceTest.java
+++ b/src/test/java/com/realestate/backend/service/SchedulerServiceTest.java
@@ -1,0 +1,203 @@
+package com.realestate.backend.service;
+
+import com.realestate.backend.entity.tenant.TenantSchemaRegistry;
+import com.realestate.backend.repository.SchemaRegistryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for SchedulerService.
+ *
+ * Strategji: mock të gjitha dependency-t, verifiko
+ * që scheduler-i thirr shërbimet e duhura për çdo schema aktive.
+ * TenantContext.set/clear nuk testohet direkt — fokusohet
+ * te interaksioni me shërbimet.
+ */
+@ExtendWith(MockitoExtension.class)
+class SchedulerServiceTest {
+
+    @Mock private PaymentService           paymentService;
+    @Mock private LeaseContractService     leaseContractService;
+    @Mock private SchemaRegistryRepository schemaRegistryRepo;
+
+    @InjectMocks
+    private SchedulerService schedulerService;
+
+    // ── Helper: krijon schema mock ──────────────────────────────
+    private TenantSchemaRegistry schema(String name, boolean provisioned) {
+        TenantSchemaRegistry s = new TenantSchemaRegistry();
+        s.setSchemaName(name);
+        s.setIsProvisioned(provisioned);
+        return s;
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // markOverduePayments
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("markOverduePayments - thirr paymentService për çdo schema aktive")
+    void markOverduePayments_callsPaymentServiceForEachActiveSchema() {
+        when(schemaRegistryRepo.findAll()).thenReturn(List.of(
+                schema("tenant_alpha_1", true),
+                schema("tenant_beta_2",  true)
+        ));
+        when(paymentService.markOverduePayments()).thenReturn(3);
+
+        schedulerService.markOverduePayments();
+
+        verify(paymentService, times(2)).markOverduePayments();
+    }
+
+    @Test
+    @DisplayName("markOverduePayments - injoron skemat e pa-provisioned")
+    void markOverduePayments_skipsUnprovisionedSchemas() {
+        when(schemaRegistryRepo.findAll()).thenReturn(List.of(
+                schema("tenant_active_1",      true),
+                schema("tenant_inactive_2",    false),
+                schema("tenant_also_active_3", true)
+        ));
+        when(paymentService.markOverduePayments()).thenReturn(0);
+
+        schedulerService.markOverduePayments();
+
+        // Vetëm 2 schema aktive → markOverduePayments thirret 2 herë
+        verify(paymentService, times(2)).markOverduePayments();
+    }
+
+    @Test
+    @DisplayName("markOverduePayments - nuk thirret fare kur nuk ka schema aktive")
+    void markOverduePayments_noActiveSchemas_doesNotCallPaymentService() {
+        when(schemaRegistryRepo.findAll()).thenReturn(List.of(
+                schema("tenant_inactive_1", false)
+        ));
+
+        schedulerService.markOverduePayments();
+
+        verify(paymentService, never()).markOverduePayments();
+    }
+
+    @Test
+    @DisplayName("markOverduePayments - vazhdon edhe kur një schema hedh exception")
+    void markOverduePayments_continuesOnException() {
+        when(schemaRegistryRepo.findAll()).thenReturn(List.of(
+                schema("tenant_bad_1",  true),
+                schema("tenant_good_2", true)
+        ));
+        when(paymentService.markOverduePayments())
+                .thenThrow(new RuntimeException("DB error"))
+                .thenReturn(2);
+
+        // Nuk duhet të hedh exception
+        schedulerService.markOverduePayments();
+
+        verify(paymentService, times(2)).markOverduePayments();
+    }
+
+    @Test
+    @DisplayName("markOverduePayments - lista bosh → nuk bëhet asnjë thirrje")
+    void markOverduePayments_emptyList_doesNothing() {
+        when(schemaRegistryRepo.findAll()).thenReturn(List.of());
+
+        schedulerService.markOverduePayments();
+
+        verify(paymentService, never()).markOverduePayments();
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // checkExpiringContracts
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("checkExpiringContracts - thirr leaseContractService.getExpiringSoon() për çdo schema")
+    void checkExpiringContracts_callsLeaseServiceForEachSchema() {
+        when(schemaRegistryRepo.findAll()).thenReturn(List.of(
+                schema("tenant_alpha_1", true),
+                schema("tenant_beta_2",  true)
+        ));
+        when(leaseContractService.getExpiringSoon()).thenReturn(List.of());
+
+        schedulerService.checkExpiringContracts();
+
+        verify(leaseContractService, times(2)).getExpiringSoon();
+    }
+
+    @Test
+    @DisplayName("checkExpiringContracts - vazhdon edhe kur gjendet exception")
+    void checkExpiringContracts_continuesOnException() {
+        when(schemaRegistryRepo.findAll()).thenReturn(List.of(
+                schema("tenant_fail_1",  true),
+                schema("tenant_ok_2",    true)
+        ));
+        when(leaseContractService.getExpiringSoon())
+                .thenThrow(new RuntimeException("timeout"))
+                .thenReturn(List.of());
+
+        schedulerService.checkExpiringContracts();
+
+        verify(leaseContractService, times(2)).getExpiringSoon();
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // logSystemStats
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("logSystemStats - thirr countActive() për çdo schema aktive")
+    void logSystemStats_callsCountActiveForEachSchema() {
+        when(schemaRegistryRepo.findAll()).thenReturn(List.of(
+                schema("tenant_x_1", true),
+                schema("tenant_y_2", true),
+                schema("tenant_z_3", true)
+        ));
+        when(leaseContractService.countActive()).thenReturn(5L);
+
+        schedulerService.logSystemStats();
+
+        verify(leaseContractService, times(3)).countActive();
+    }
+
+    @Test
+    @DisplayName("logSystemStats - nuk thirr countActive() kur lista është bosh")
+    void logSystemStats_emptySchemas_doesNotCallCountActive() {
+        when(schemaRegistryRepo.findAll()).thenReturn(List.of());
+
+        schedulerService.logSystemStats();
+
+        verify(leaseContractService, never()).countActive();
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // healthCheck
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("healthCheck - thirr schemaRegistryRepo.findAll()")
+    void healthCheck_callsFindAll() {
+        when(schemaRegistryRepo.findAll()).thenReturn(List.of(
+                schema("tenant_a_1", true)
+        ));
+
+        schedulerService.healthCheck();
+
+        verify(schemaRegistryRepo, atLeastOnce()).findAll();
+    }
+
+    @Test
+    @DisplayName("healthCheck - nuk thirr shërbime të tjera")
+    void healthCheck_doesNotCallOtherServices() {
+        when(schemaRegistryRepo.findAll()).thenReturn(List.of());
+
+        schedulerService.healthCheck();
+
+        verifyNoInteractions(paymentService, leaseContractService);
+    }
+}

--- a/src/test/java/com/realestate/backend/service/SchemaProvisioningServiceTest.java
+++ b/src/test/java/com/realestate/backend/service/SchemaProvisioningServiceTest.java
@@ -1,0 +1,159 @@
+package com.realestate.backend.service;
+
+import com.realestate.backend.entity.tenant.TenantCompany;
+import com.realestate.backend.entity.tenant.TenantSchemaRegistry;
+import com.realestate.backend.repository.SchemaRegistryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.sql.DataSource;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for SchemaProvisioningService.
+ *
+ * Sipas kërkesës së issue: fokusohet VETËM në provisionIfNeeded()
+ * e cila mund të testohet me mock pa nevojë për Flyway/DataSource real.
+ *
+ * provision() nuk testohet direkt sepse kërkon DataSource + Flyway
+ * dhe do të ishte integration test, jo unit test.
+ */
+@ExtendWith(MockitoExtension.class)
+class SchemaProvisioningServiceTest {
+
+    @Mock private SchemaRegistryRepository schemaRegistryRepository;
+    @Mock private DataSource               dataSource;
+
+    @InjectMocks
+    private SchemaProvisioningService provisioningService;
+
+    // ── Helpers ─────────────────────────────────────────────────
+    private TenantCompany buildTenant(Long id, String slug) {
+        return TenantCompany.builder()
+                .id(id).name("Test Corp").slug(slug)
+                .plan("FREE").isActive(true)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private TenantSchemaRegistry buildRegistry(TenantCompany tenant, String schemaName) {
+        TenantSchemaRegistry reg = new TenantSchemaRegistry();
+        reg.setTenant(tenant);
+        reg.setSchemaName(schemaName);
+        reg.setIsProvisioned(true);
+        reg.setProvisionedAt(LocalDateTime.now());
+        return reg;
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // provisionIfNeeded — schema ekziston tashmë
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("provisionIfNeeded - schema ekziston → kthehej schemaName direkt pa provision")
+    void provisionIfNeeded_schemaAlreadyExists_returnsExistingSchemaName() {
+        TenantCompany tenant = buildTenant(1L, "acme-corp");
+        TenantSchemaRegistry existing = buildRegistry(tenant, "tenant_acme_corp_1");
+
+        when(schemaRegistryRepository.findByTenant_IdAndIsProvisionedTrue(1L))
+                .thenReturn(Optional.of(existing));
+
+        String result = provisioningService.provisionIfNeeded(tenant);
+
+        assertThat(result).isEqualTo("tenant_acme_corp_1");
+        // provision() NUK duhet të thirret — DataSource nuk preket
+        verifyNoInteractions(dataSource);
+    }
+
+    @Test
+    @DisplayName("provisionIfNeeded - schema ekziston → nuk thirret save() në registry")
+    void provisionIfNeeded_schemaExists_doesNotSaveNewRegistry() {
+        TenantCompany tenant = buildTenant(2L, "beta-re");
+        TenantSchemaRegistry existing = buildRegistry(tenant, "tenant_beta_re_2");
+
+        when(schemaRegistryRepository.findByTenant_IdAndIsProvisionedTrue(2L))
+                .thenReturn(Optional.of(existing));
+
+        provisioningService.provisionIfNeeded(tenant);
+
+        verify(schemaRegistryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("provisionIfNeeded - thirr findByTenant_IdAndIsProvisionedTrue me ID të saktë")
+    void provisionIfNeeded_callsRepositoryWithCorrectId() {
+        TenantCompany tenant = buildTenant(42L, "gamma-prop");
+        TenantSchemaRegistry existing = buildRegistry(tenant, "tenant_gamma_prop_42");
+
+        when(schemaRegistryRepository.findByTenant_IdAndIsProvisionedTrue(42L))
+                .thenReturn(Optional.of(existing));
+
+        provisioningService.provisionIfNeeded(tenant);
+
+        verify(schemaRegistryRepository).findByTenant_IdAndIsProvisionedTrue(42L);
+    }
+
+    @Test
+    @DisplayName("provisionIfNeeded - kthehej emri i saktë i schemës ekzistuese")
+    void provisionIfNeeded_returnsCorrectSchemaNameFromRegistry() {
+        TenantCompany tenant = buildTenant(10L, "delta-estates");
+        String expectedSchema = "tenant_delta_estates_10";
+        TenantSchemaRegistry existing = buildRegistry(tenant, expectedSchema);
+
+        when(schemaRegistryRepository.findByTenant_IdAndIsProvisionedTrue(10L))
+                .thenReturn(Optional.of(existing));
+
+        String result = provisioningService.provisionIfNeeded(tenant);
+
+        assertThat(result).isEqualTo(expectedSchema);
+    }
+
+    @Test
+    @DisplayName("provisionIfNeeded - schema nuk ekziston → thirret provision() (DataSource needed)")
+    void provisionIfNeeded_noSchema_attemptsProvisioning() {
+        TenantCompany tenant = buildTenant(5L, "new-tenant");
+
+        when(schemaRegistryRepository.findByTenant_IdAndIsProvisionedTrue(5L))
+                .thenReturn(Optional.empty());
+
+        // provision() do të dështojë sepse DataSource mock nuk jep Connection real
+        // Por kjo konfirmon që provisionIfNeeded() e thirri provision() kur schema mungon
+        assertThatThrownBy(() -> provisioningService.provisionIfNeeded(tenant))
+                .isInstanceOf(RuntimeException.class);
+
+        // Konfirmon se u tentua provision (findByTenant_IdAndIsProvisionedTrue u thirr)
+        verify(schemaRegistryRepository).findByTenant_IdAndIsProvisionedTrue(5L);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // schemaName generation logic — testuar indirekt
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("provisionIfNeeded - slug me vizë → zëvendësohet me _ në schemaName")
+    void provisionIfNeeded_slugWithDash_schemaNameUsesUnderscore() {
+        // Konfirmon logjikën: "acme-corp" → "tenant_acme_corp_1"
+        // Testohet indirekt duke parë schemaName të ruajtur në registry
+        TenantCompany tenant = buildTenant(1L, "acme-corp");
+        String expectedSchema = "tenant_acme_corp_1"; // - → _
+        TenantSchemaRegistry existing = buildRegistry(tenant, expectedSchema);
+
+        when(schemaRegistryRepository.findByTenant_IdAndIsProvisionedTrue(1L))
+                .thenReturn(Optional.of(existing));
+
+        String result = provisioningService.provisionIfNeeded(tenant);
+
+        // Nëse schema ekziston me emrin e saktë, logjika e emërtimit funksionon
+        assertThat(result).doesNotContain("-");
+        assertThat(result).startsWith("tenant_");
+        assertThat(result).endsWith("_1");
+    }
+}

--- a/src/test/java/com/realestate/backend/service/TenantServiceTest.java
+++ b/src/test/java/com/realestate/backend/service/TenantServiceTest.java
@@ -1,0 +1,252 @@
+package com.realestate.backend.service;
+
+import com.realestate.backend.dto.request.TenantRequest;
+import com.realestate.backend.dto.response.TenantResponse;
+import com.realestate.backend.entity.tenant.TenantCompany;
+import com.realestate.backend.entity.tenant.TenantSchemaRegistry;
+import com.realestate.backend.exception.ConflictException;
+import com.realestate.backend.exception.ResourceNotFoundException;
+import com.realestate.backend.repository.SchemaRegistryRepository;
+import com.realestate.backend.repository.TenantRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for TenantService.
+ *
+ * Mbulon: createTenant, getAllTenants, getTenantById, deactivateTenant.
+ * Të gjitha interaksionet me DB janë mock.
+ */
+@ExtendWith(MockitoExtension.class)
+class TenantServiceTest {
+
+    @Mock private TenantRepository           tenantRepository;
+    @Mock private SchemaRegistryRepository   schemaRegistryRepository;
+    @Mock private SchemaProvisioningService  provisioningService;
+
+    @InjectMocks
+    private TenantService tenantService;
+
+    // ── Helpers ─────────────────────────────────────────────────
+    private TenantCompany buildTenant(Long id, String name, String slug) {
+        return TenantCompany.builder()
+                .id(id).name(name).slug(slug)
+                .plan("FREE").isActive(true)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private TenantSchemaRegistry buildRegistry(TenantCompany tenant, String schemaName) {
+        TenantSchemaRegistry reg = new TenantSchemaRegistry();
+        reg.setTenant(tenant);
+        reg.setSchemaName(schemaName);
+        reg.setIsProvisioned(true);
+        reg.setProvisionedAt(LocalDateTime.now());
+        return reg;
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // createTenant
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("createTenant - krijon tenant dhe provizion schema me sukses")
+    void createTenant_success() {
+        TenantRequest req = new TenantRequest("Acme RE", "acme-re", "PRO");
+
+        TenantCompany saved = buildTenant(1L, "Acme RE", "acme-re");
+        saved.setPlan("PRO");
+
+        when(tenantRepository.existsBySlug("acme-re")).thenReturn(false);
+        when(tenantRepository.existsByName("Acme RE")).thenReturn(false);
+        when(tenantRepository.save(any())).thenReturn(saved);
+        when(provisioningService.provisionIfNeeded(saved)).thenReturn("tenant_acme_re_1");
+
+        TenantResponse resp = tenantService.createTenant(req);
+
+        assertThat(resp.name()).isEqualTo("Acme RE");
+        assertThat(resp.schemaName()).isEqualTo("tenant_acme_re_1");
+        assertThat(resp.isProvisioned()).isTrue();
+
+        verify(tenantRepository).save(any(TenantCompany.class));
+        verify(provisioningService).provisionIfNeeded(saved);
+    }
+
+    @Test
+    @DisplayName("createTenant - hedh ConflictException kur slug ekziston")
+    void createTenant_duplicateSlug_throwsConflict() {
+        TenantRequest req = new TenantRequest("Beta Corp", "beta-corp", "FREE");
+
+        when(tenantRepository.existsBySlug("beta-corp")).thenReturn(true);
+
+        assertThatThrownBy(() -> tenantService.createTenant(req))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("beta-corp");
+
+        verify(tenantRepository, never()).save(any());
+        verifyNoInteractions(provisioningService);
+    }
+
+    @Test
+    @DisplayName("createTenant - hedh ConflictException kur emri ekziston")
+    void createTenant_duplicateName_throwsConflict() {
+        TenantRequest req = new TenantRequest("Existing Corp", "new-slug", "FREE");
+
+        when(tenantRepository.existsBySlug("new-slug")).thenReturn(false);
+        when(tenantRepository.existsByName("Existing Corp")).thenReturn(true);
+
+        assertThatThrownBy(() -> tenantService.createTenant(req))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("Existing Corp");
+
+        verify(tenantRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("createTenant - plan null → default FREE")
+    void createTenant_nullPlan_defaultsFree() {
+        TenantRequest req = new TenantRequest("Free Co", "free-co", null);
+
+        TenantCompany saved = buildTenant(2L, "Free Co", "free-co");
+        saved.setPlan("FREE");
+
+        when(tenantRepository.existsBySlug("free-co")).thenReturn(false);
+        when(tenantRepository.existsByName("Free Co")).thenReturn(false);
+        when(tenantRepository.save(any())).thenReturn(saved);
+        when(provisioningService.provisionIfNeeded(saved)).thenReturn("tenant_free_co_2");
+
+        TenantResponse resp = tenantService.createTenant(req);
+
+        assertThat(resp.plan()).isEqualTo("FREE");
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // getAllTenants
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("getAllTenants - kthen listë të gjitha tenant-ëve me schema")
+    void getAllTenants_returnsList() {
+        TenantCompany t1 = buildTenant(1L, "Alpha",  "alpha");
+        TenantCompany t2 = buildTenant(2L, "Beta",   "beta");
+
+        when(tenantRepository.findAll()).thenReturn(List.of(t1, t2));
+        when(schemaRegistryRepository.findByTenant_Id(1L))
+                .thenReturn(Optional.of(buildRegistry(t1, "tenant_alpha_1")));
+        when(schemaRegistryRepository.findByTenant_Id(2L))
+                .thenReturn(Optional.empty());
+
+        List<TenantResponse> result = tenantService.getAllTenants();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).name()).isEqualTo("Alpha");
+        assertThat(result.get(0).schemaName()).isEqualTo("tenant_alpha_1");
+        assertThat(result.get(0).isProvisioned()).isTrue();
+
+        // Beta nuk ka schema → null, false
+        assertThat(result.get(1).name()).isEqualTo("Beta");
+        assertThat(result.get(1).schemaName()).isNull();
+        assertThat(result.get(1).isProvisioned()).isFalse();
+    }
+
+    @Test
+    @DisplayName("getAllTenants - lista bosh kthen listë bosh")
+    void getAllTenants_emptyList() {
+        when(tenantRepository.findAll()).thenReturn(List.of());
+
+        List<TenantResponse> result = tenantService.getAllTenants();
+
+        assertThat(result).isEmpty();
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // getTenantById
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("getTenantById - kthen tenant me schema")
+    void getTenantById_found() {
+        TenantCompany tenant = buildTenant(5L, "Gamma Corp", "gamma");
+
+        when(tenantRepository.findById(5L)).thenReturn(Optional.of(tenant));
+        when(schemaRegistryRepository.findByTenant_Id(5L))
+                .thenReturn(Optional.of(buildRegistry(tenant, "tenant_gamma_5")));
+
+        TenantResponse resp = tenantService.getTenantById(5L);
+
+        assertThat(resp.id()).isEqualTo(5L);
+        assertThat(resp.name()).isEqualTo("Gamma Corp");
+        assertThat(resp.schemaName()).isEqualTo("tenant_gamma_5");
+    }
+
+    @Test
+    @DisplayName("getTenantById - hedh ResourceNotFoundException kur nuk gjendet")
+    void getTenantById_notFound_throwsException() {
+        when(tenantRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tenantService.getTenantById(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // deactivateTenant
+    // ══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("deactivateTenant - vendos isActive = false dhe ruhet")
+    void deactivateTenant_setsInactiveAndSaves() {
+        TenantCompany tenant = buildTenant(3L, "Delta", "delta");
+        assertThat(tenant.getIsActive()).isTrue();
+
+        when(tenantRepository.findById(3L)).thenReturn(Optional.of(tenant));
+        when(tenantRepository.save(tenant)).thenReturn(tenant);
+        when(schemaRegistryRepository.findByTenant_Id(3L))
+                .thenReturn(Optional.of(buildRegistry(tenant, "tenant_delta_3")));
+
+        TenantResponse resp = tenantService.deactivateTenant(3L);
+
+        assertThat(tenant.getIsActive()).isFalse();
+        assertThat(resp.isActive()).isFalse();
+        verify(tenantRepository).save(tenant);
+    }
+
+    @Test
+    @DisplayName("deactivateTenant - hedh ResourceNotFoundException kur tenant nuk gjendet")
+    void deactivateTenant_notFound_throwsException() {
+        when(tenantRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tenantService.deactivateTenant(404L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("404");
+
+        verify(tenantRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("deactivateTenant - thirr save() saktësisht një herë")
+    void deactivateTenant_savesExactlyOnce() {
+        TenantCompany tenant = buildTenant(7L, "Epsilon", "epsilon");
+
+        when(tenantRepository.findById(7L)).thenReturn(Optional.of(tenant));
+        when(tenantRepository.save(tenant)).thenReturn(tenant);
+        when(schemaRegistryRepository.findByTenant_Id(7L))
+                .thenReturn(Optional.empty());
+
+        tenantService.deactivateTenant(7L);
+
+        verify(tenantRepository, times(1)).save(tenant);
+    }
+}


### PR DESCRIPTION
## Përshkrimi
Në këtë PR janë shtuar unit teste për:
- AiService
- SchedulerService
- TenantService
- SchemaProvisioningService

Testet janë implementuar duke përdorur:
- JUnit 5
- Mockito
- @ExtendWith(MockitoExtension.class)

Nuk është përdorur lidhje reale me databazë, ndërsa dependency-t janë mock-uar sipas kërkesës së issue-it.

Gjithashtu janë testuar:
- rastet pozitive
- validimet
- exception handling
- background jobs/scheduler logic
- tenant provisioning logic

Testet janë ekzekutuar me:
bash
./mvnw test

Rezultati:
86 teste kaluan me sukses
0 failures
0 errors

Closes #64 