### PR TITLE
[FIX] Add @JsonProperty to listing_type in PropertyCreateRequest

### DIFF
--- a/src/main/java/com/realestate/backend/dto/property/PropertyDtos.java
+++ b/src/main/java/com/realestate/backend/dto/property/PropertyDtos.java
@@ -53,6 +53,7 @@ public class PropertyDtos {
             @Schema(allowableValues = {"APARTMENT","HOUSE","VILLA","COMMERCIAL","LAND","OFFICE"})
             PropertyType type,
 
+            @JsonProperty("listing_type")
             @Schema(allowableValues = {"SALE","RENT","BOTH"})
             ListingType listingType,
 


### PR DESCRIPTION
Bug: Kur agjenti krijonte pronë nga një lead RENT,
listing_type në DB insertohet gjithmonë si SALE.

Shkaku:
- PropertyCreateRequest ka fushën ListingType listingType
- Jackson e pret si "listingType" (camelCase)
- Frontend dërgon "listing_type" (snake_case)
- Map-imi dështonte → listingType mbetej null
- PropertyService: listingType != null ? listingType : SALE
  → gjithmonë ekzekutohej SALE

Fix:
@JsonProperty("listing_type")
ListingType listingType,

Tested:
- Lead RENT → prona krijohet me listing_type = RENT ✓
- Lead SELL → prona krijohet me listing_type = SALE ✓

Closes #88 