### PR TITLE
Allow agents to access client profiles

### DIFF
--- a/src/main/resources/db/migration/public/V16__fix_agent_client_read_permission.sql
+++ b/src/main/resources/db/migration/public/V16__fix_agent_client_read_permission.sql
@@ -1,0 +1,6 @@
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM public.roles r
+JOIN public.permissions p ON p.name = 'user.clients.read'
+WHERE r.name = 'AGENT'
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Ky PR rregullon problemin ku agjenti merrte 403 Forbidden kur tentonte të lexonte profilin e një klienti përmes endpoint-it:

GET /api/users/clients/{clientId}

Shkaku ishte se permission-i user.clients.read ekzistonte, por nuk ishte i lidhur me rolin AGENT.

Ndryshimi i bërë:
- Shtohet migration i ri për t’i dhënë rolit AGENT permission-in user.clients.read

Pas këtij ndryshimi, agjenti mund të hapë profilin e klientit pa marrë 403 Forbidden.

Closes #90 