### PR TITLE
feat: impersonation backend — controller, JWT dhe permissions

### DIFF
--- a/src/main/java/com/realestate/backend/controller/ImpersonationController.java
+++ b/src/main/java/com/realestate/backend/controller/ImpersonationController.java
@@ -1,0 +1,105 @@
+package com.realestate.backend.controller;
+
+import com.realestate.backend.entity.User;
+import com.realestate.backend.entity.tenant.TenantSchemaRegistry;
+import com.realestate.backend.multitenancy.TenantContext;
+import com.realestate.backend.repository.SchemaRegistryRepository;
+import com.realestate.backend.repository.UserRepository;
+import com.realestate.backend.security.jwt.JwtUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * ImpersonationController — allows ADMIN to act as another user.
+ *
+ * Generates a new JWT token with the target user's claims plus an
+ * "impersonatedBy" field so every action is traceable back to the
+ * original admin. The admin's original token is never invalidated —
+ * the frontend simply swaps tokens and restores the original on exit.
+ *
+ * Security rules enforced:
+ *   - Only ADMIN can impersonate
+ *   - Cannot impersonate another ADMIN
+ *   - Cannot impersonate a user from a different tenant
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/admin/impersonate")
+@RequiredArgsConstructor
+@Tag(name = "Impersonation")
+@SecurityRequirement(name = "BearerAuth")
+public class ImpersonationController extends BaseController {
+
+    private final UserRepository           userRepository;
+    private final SchemaRegistryRepository schemaRegistryRepository;
+    private final JwtUtil                  jwtUtil;
+
+    @PostMapping("/{userId}")
+    @Operation(summary = "Start impersonating a user (ADMIN only)")
+    public ResponseEntity<Map<String, String>> impersonate(
+            @PathVariable Long userId) {
+
+        // Only ADMIN can impersonate
+        if (!"ADMIN".equals(TenantContext.getRole())) {
+            return ResponseEntity.status(403)
+                    .body(Map.of("error", "Only ADMIN can impersonate users"));
+        }
+
+        // Find target user
+        User target = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found: " + userId));
+
+        // Cannot impersonate another ADMIN
+        if ("ADMIN".equals(target.getRole().name())) {
+            return ResponseEntity.status(403)
+                    .body(Map.of("error", "Cannot impersonate another ADMIN"));
+        }
+
+        // Cannot impersonate cross-tenant
+        if (!target.getTenant().getId().equals(TenantContext.getTenantId())) {
+            return ResponseEntity.status(403)
+                    .body(Map.of("error", "Cannot impersonate user from a different tenant"));
+        }
+
+        // Find schema
+        String schemaName = schemaRegistryRepository
+                .findByTenant_Id(target.getTenant().getId())
+                .map(TenantSchemaRegistry::getSchemaName)
+                .orElseThrow(() -> new RuntimeException("Schema not found for tenant"));
+
+        // Generate impersonation token
+        String token = jwtUtil.generateImpersonationToken(
+                target.getId(),
+                target.getEmail(),
+                target.getTenant().getId(),
+                schemaName,
+                target.getRole().name(),
+                TenantContext.getUserId()
+        );
+
+        log.warn("IMPERSONATION STARTED — admin={} impersonating userId={}",
+                TenantContext.getUserId(), userId);
+
+        return ok(Map.of(
+                "token",     token,
+                "email",     target.getEmail(),
+                "role",      target.getRole().name(),
+                "full_name", (target.getFirstName() + " " + target.getLastName()).trim(),
+                "message",   "Now acting as " + target.getEmail()
+        ));
+    }
+
+    @PostMapping("/exit")
+    @Operation(summary = "Exit impersonation — frontend restores original token")
+    public ResponseEntity<Map<String, String>> exit() {
+        log.info("IMPERSONATION EXIT — userId={}", TenantContext.getUserId());
+        return ok(Map.of("message", "Impersonation exited — restore your original token"));
+    }
+}

--- a/src/main/java/com/realestate/backend/security/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/realestate/backend/security/jwt/JwtAuthFilter.java
@@ -100,6 +100,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             log.debug("JWT valid — user={}, tenant={}, schema={}, role={}",
                     userId, tenantId, schemaName, role);
 
+            // Log impersonation if active
+            Long impersonatedBy = jwtUtil.extractImpersonatedBy(token);
+            if (impersonatedBy != null) {
+                log.warn("IMPERSONATION ACTIVE — admin={} acting as userId={}",
+                        impersonatedBy, userId);
+            }
+
 
             TenantContext.set(userId, tenantId, schemaName, role);
 

--- a/src/main/java/com/realestate/backend/security/jwt/JwtUtil.java
+++ b/src/main/java/com/realestate/backend/security/jwt/JwtUtil.java
@@ -93,6 +93,30 @@ public class JwtUtil {
                 .compact();
     }
 
+    public String generateImpersonationToken(
+            Long userId, String email, Long tenantId,
+            String schemaName, String role, Long impersonatedBy) {
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("userId",         userId);
+        claims.put("tenantId",       tenantId);
+        claims.put("schemaName",     schemaName);
+        claims.put("role",           role);
+        claims.put("impersonatedBy", impersonatedBy);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + jwtExpirationMs))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    public Long extractImpersonatedBy(String token) {
+        return extractAllClaims(token).get("impersonatedBy", Long.class);
+    }
+
     public Claims extractAllClaims(String token) {
         return Jwts.parser()
                 .verifyWith(getSigningKey())

--- a/src/main/resources/db/migration/public/V17__impersonate_permission.sql
+++ b/src/main/resources/db/migration/public/V17__impersonate_permission.sql
@@ -1,0 +1,14 @@
+
+INSERT INTO public.permissions (name, http_method, api_path, description)
+VALUES
+    ('admin.impersonate.start', 'POST', '/api/admin/impersonate/*', 'Impersonate a user'),
+    ('admin.impersonate.exit',  'POST', '/api/admin/impersonate/exit', 'Exit impersonation')
+ON CONFLICT (name) DO NOTHING;
+
+
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM public.roles r, public.permissions p
+WHERE r.name = 'ADMIN'
+  AND p.name IN ('admin.impersonate.start', 'admin.impersonate.exit')
+ON CONFLICT DO NOTHING;

--- a/src/main/resources/db/migration/public/V18__profile_permissions.sql
+++ b/src/main/resources/db/migration/public/V18__profile_permissions.sql
@@ -1,0 +1,11 @@
+INSERT INTO public.permissions (name, http_method, api_path, description)
+VALUES
+    ('user.agents.read',  'GET', '/api/users/agents/*',  'Get agent profile'),
+    ('user.clients.read', 'GET', '/api/users/clients/*', 'Get client profile')
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT r.id, p.id FROM public.roles r, public.permissions p
+WHERE r.name = 'ADMIN'
+  AND p.name IN ('user.agents.read', 'user.clients.read')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION

Përshkrimi:
Shtimi i features së impersonation në backend duke lejuar adminët
të veprojnë si user tjetër brenda të njëjtit tenant.

## Skedarët e ndryshuar
- ImpersonationController.java (i ri) — endpoint start dhe exit
- JwtUtil.java — generateImpersonationToken() dhe extractImpersonatedBy()
- JwtAuthFilter.java — detektim dhe logging i impersonation aktive
- V13__impersonation_permissions.sql (i ri) — permissions në DB

## Si funksionon
Admin dërgon POST /api/admin/impersonate/{userId} →
backend validon rregullat e sigurisë →
gjeneron token të ri me claim impersonatedBy →
frontend e merr token-in dhe bën swap

## Rregullat e sigurisë të implementuara
- Vetëm ADMIN mund të thirr endpointet
- Nuk lejohet impersonation i ADMIN tjetër
- Nuk lejohet impersonation cross-tenant
- Çdo start loggohet me WARN nivel

## Breaking changes
Asnjë — endpoint-et janë plotësisht të rinj


Closes #94 