### PR TITLE
 fix: populate search_vector and add trigger for full-text search

### DIFF
--- a/src/main/java/com/realestate/backend/repository/PropertyRepository.java
+++ b/src/main/java/com/realestate/backend/repository/PropertyRepository.java
@@ -41,16 +41,16 @@ public interface PropertyRepository
 
     @Query(
             value = """
-            SELECT * FROM properties
-            WHERE search_vector @@ plainto_tsquery('english', :keyword)
-              AND deleted_at IS NULL
-            ORDER BY ts_rank(search_vector, plainto_tsquery('english', :keyword)) DESC
-            """,
+        SELECT * FROM properties
+        WHERE search_vector @@ plainto_tsquery('simple', :keyword)
+          AND deleted_at IS NULL
+        ORDER BY ts_rank(search_vector, plainto_tsquery('simple', :keyword)) DESC
+        """,
             countQuery = """
-            SELECT COUNT(*) FROM properties
-            WHERE search_vector @@ plainto_tsquery('english', :keyword)
-              AND deleted_at IS NULL
-            """,
+        SELECT COUNT(*) FROM properties
+        WHERE search_vector @@ plainto_tsquery('simple', :keyword)
+          AND deleted_at IS NULL
+        """,
             nativeQuery = true
     )
     Page<Property> fullTextSearch(

--- a/src/main/resources/db/migration/tenant/V20__property_searchvector_trigger.sql
+++ b/src/main/resources/db/migration/tenant/V20__property_searchvector_trigger.sql
@@ -1,0 +1,25 @@
+
+
+CREATE OR REPLACE FUNCTION update_search_vector()
+    RETURNS TRIGGER AS $$
+BEGIN
+    NEW.search_vector := to_tsvector(
+            'simple',
+            COALESCE(NEW.title, '')                      || ' ' ||
+            COALESCE(NEW.description, '')                || ' ' ||
+            COALESCE(CAST(NEW.type AS text), '')         || ' ' ||
+            COALESCE(CAST(NEW.listing_type AS text), '')
+                         );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_properties_search ON properties;
+
+CREATE TRIGGER trg_properties_search
+    BEFORE INSERT OR UPDATE ON properties
+    FOR EACH ROW EXECUTE FUNCTION update_search_vector();
+
+UPDATE properties
+SET title = title
+WHERE deleted_at IS NULL;


### PR DESCRIPTION

Përshkrimi:
## Problemi
GET /api/properties/search po kthente content:[] për çdo keyword
edhe pse pronat ekzistonin. Kolona search_vector ishte NULL
për të gjitha rreshtat ekzistues.

## Ndryshimet

### V20__property_search_vector_trigger.sql (i ri)
- Krijon funksionin update_search_vector() me gjuhë 'simple'
- Krijon trigger trg_properties_search — BEFORE INSERT OR UPDATE
- Populon search_vector për pronat ekzistuese me:
  UPDATE properties SET title = title WHERE deleted_at IS NULL
  (kjo e trigger-on trigger-in për çdo rresht pa ndryshuar të dhëna)
- Flyway e ekzekuton automatikisht për çdo tenant schema të re

### PropertyRepository.java
- plainto_tsquery('english') → plainto_tsquery('simple')
- to_tsvector('english') → to_tsvector('simple')

## Pse 'simple' jo 'english'
'english' aplikon stemming vetëm për fjalë angleze.
'simple' funksionon me çdo gjuhë — shqip, anglisht, ose të përziera
që është rasti i titujve të pronave në këtë sistem.


## Testimi
- GET /api/properties/search?keyword=villa → rezultate 
- GET /api/properties/search?keyword=apartment → rezultate 
- Prona e re e krijuar → search_vector populohet automatikisht 

Closes #97 