### PR TITLE
Add agent rating endpoint and fix CLIENT permissions

### DIFF
--- a/src/main/java/com/realestate/backend/controller/UserController.java
+++ b/src/main/java/com/realestate/backend/controller/UserController.java
@@ -12,7 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/users")
@@ -123,6 +125,16 @@ public class UserController extends BaseController {
             @Valid @RequestBody AgentProfileRequest request) {
         return ok(agentProfileService.updateProfile(userId, request));
     }
+
+    @PatchMapping("/agents/{userId}/rate")
+    @Operation(summary = "Rate an agent (CLIENT)")
+    public ResponseEntity<Void> rateAgent(
+            @PathVariable Long userId,
+            @RequestBody Map<String, Double> body) {
+        agentProfileService.addRating(userId, BigDecimal.valueOf(body.get("rating")));
+        return noContent();
+    }
+
 
     // ══════════════════ CLIENT PROFILES ══════════════════════════
 

--- a/src/main/java/com/realestate/backend/service/AgentProfileService.java
+++ b/src/main/java/com/realestate/backend/service/AgentProfileService.java
@@ -94,6 +94,29 @@ public class AgentProfileService {
         return toResponse(saved);
     }
 
+    @Transactional
+    public void addRating(Long userId, BigDecimal newStarScore) {
+        AgentProfile profile = agentProfileRepo.findByUserId(userId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Profili i agjentit nuk u gjet për user: " + userId));
+
+        int currentReviews = profile.getTotalReviews() != null ? profile.getTotalReviews() : 0;
+        BigDecimal currentRating = profile.getRating() != null ? profile.getRating() : BigDecimal.ZERO;
+
+        int newReviews = currentReviews + 1;
+        BigDecimal newRating = currentRating
+                .multiply(BigDecimal.valueOf(currentReviews))
+                .add(newStarScore)
+                .divide(BigDecimal.valueOf(newReviews), 2, java.math.RoundingMode.HALF_UP);
+
+        profile.setRating(newRating);
+        profile.setTotalReviews(newReviews);
+        agentProfileRepo.save(profile);
+
+        log.info("Agent userId={} u vlerësua me {} yje, rating i ri={}, total reviews={}",
+                userId, newStarScore, newRating, newReviews);
+    }
+
     // Helpers
 
     private void validateAgentProfileRequest(AgentProfileRequest req) {

--- a/src/main/java/com/realestate/backend/service/UserService.java
+++ b/src/main/java/com/realestate/backend/service/UserService.java
@@ -176,7 +176,6 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public List<UserResponse> getAgentsInTenant() {
-        assertIsAdminOrAgent();  // ← lejon edhe AGENT
         return userRepository.findAllByTenantId(TenantContext.getTenantId())
                 .stream()
                 .filter(u -> "AGENT".equalsIgnoreCase(u.getRole().name()))
@@ -184,12 +183,6 @@ public class UserService {
                 .toList();
     }
 
-    // Shto helper nëse nuk ekziston
-    private void assertIsAdminOrAgent() {
-        if (!TenantContext.hasRole("ADMIN", "AGENT")) {
-            throw new ForbiddenException("Vetëm ADMIN ose AGENT mund të kryejë këtë veprim");
-        }
-    }
     // Helpers
 
     private User findUser(Long id) {

--- a/src/main/resources/db/migration/public/V20__client_agents_permissions.sql
+++ b/src/main/resources/db/migration/public/V20__client_agents_permissions.sql
@@ -1,0 +1,10 @@
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM public.roles r
+JOIN public.permissions p ON p.name IN (
+    'user.agents.list',
+    'user.agents.all',
+    'user.agents.read'
+)
+WHERE r.name = 'CLIENT'
+ON CONFLICT DO NOTHING;

--- a/src/main/resources/db/migration/public/V21__client_agents_rate_permission.sql
+++ b/src/main/resources/db/migration/public/V21__client_agents_rate_permission.sql
@@ -1,0 +1,9 @@
+INSERT INTO public.permissions (name, http_method, api_path, description)
+VALUES ('agent.rate', 'PATCH', '/api/users/agents/*/rate', 'Rate an agent')
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM public.roles r, public.permissions p
+WHERE r.name = 'CLIENT' AND p.name = 'agent.rate'
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
U shtua endpoint i dedikuar për vlerësimin e agjentëve nga klientët 
dhe u rregulluan permissions që mungonin për rolin CLIENT.

## Ndryshimet
- V15_client_agents_permissions.sql — permissions user.agents.list/all/read për CLIENT
- UserService.java — hoqëm assertIsAdminOrAgent() nga getAgentsInTenant()
- AgentProfileService.java — metoda addRating() me llogaritje mesatare
- UserController.java — endpoint i ri PATCH /api/users/agents/{userId}/rate
- V16_agent_rate_permission.sql — permission agent.rate vetëm për CLIENT

## Si të testohet
1. Ekzeuto migrations V15 dhe V16
2. Logohu si CLIENT
3. Thirr GET /api/users/agents/list — duhet 200
4. Thirr PATCH /api/users/agents/1/rate me body {"rating": 4} — duhet 204
5. Verifiko që rating-u i agjentit u përditësua në DB

Closes #99 