### PR TITLE
Use findAll with explicit PageRequest and sort

### DIFF
--- a/src/main/java/com/realestate/backend/service/LeaseContractService.java
+++ b/src/main/java/com/realestate/backend/service/LeaseContractService.java
@@ -52,7 +52,13 @@ public class LeaseContractService {
     // ── Listim ───────────────────────────────────────────────────
     @Transactional(readOnly = true)
     public Page<LeaseContractSummary> getAll(Pageable pageable) {
-        return contractRepo.findByStatusOrderByCreatedAtDesc(LeaseStatus.ACTIVE, pageable)
+        return contractRepo.findAll(
+                        org.springframework.data.domain.PageRequest.of(
+                                pageable.getPageNumber(),
+                                pageable.getPageSize(),
+                                org.springframework.data.domain.Sort.by(
+                                        org.springframework.data.domain.Sort.Direction.DESC, "createdAt")
+                        ))
                 .map(this::toSummary);
     }
 


### PR DESCRIPTION
Ky PR përditëson query-n për listimin e kontratave duke larguar filtrimin vetëm për ACTIVE contracts dhe duke përdorur një `PageRequest` explicit me sorting sipas `createdAt` në descending order.

### Ndryshimet Kryesore

* U zëvendësua:

  * `contractRepo.findByStatusOrderByCreatedAtDesc(LeaseStatus.ACTIVE, pageable)`

* Me:

  * `contractRepo.findAll(PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.DESC, "createdAt"))).map(this::toSummary)`

* U largua filtrimi sipas:

  * `LeaseStatus.ACTIVE`

* Rezultatet tani përfshijnë:

  * të gjitha kontratat
  * jo vetëm ACTIVE contracts

* U shtua explicit sorting:

  * `createdAt DESC`

* Pagination behavior mbetet konsistent

* U bënë cleanup/refactor improvements të vogla

### Rezultati

* Listimi i kontratave tani përfshin të gjitha statuset
* Sorting është më i kontrolluar dhe explicit
* Query logic është më fleksibël dhe më e mirëmbajtshme
Close #104  
