### PR TITLE
[ADMIN] Refactor: AdminAiController — extract business logic to AdminAiService

### DIFF
--- a/src/main/java/com/realestate/backend/controller/AdminAiController.java
+++ b/src/main/java/com/realestate/backend/controller/AdminAiController.java
@@ -1,16 +1,13 @@
 package com.realestate.backend.controller;
 
 import com.realestate.backend.dto.ai.AiDtos.*;
-import com.realestate.backend.entity.enums.LeadStatus;
-import com.realestate.backend.repository.*;
-import com.realestate.backend.service.AiService;
+import com.realestate.backend.service.AdminAiService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import java.math.BigDecimal;
 
 @RestController
 @RequestMapping("/api/admin/ai")
@@ -19,51 +16,12 @@ import java.math.BigDecimal;
 @SecurityRequirement(name = "BearerAuth")
 public class AdminAiController extends BaseController {
 
-    private final AiService              aiService;
-    private final UserRepository         userRepo;
-    private final LeadRequestRepository  leadRepo;
-    private final LeaseContractRepository contractRepo;
-    private final SaleContractRepository saleContractRepo;
-    private final PaymentRepository      paymentRepo;
+    private final AdminAiService adminAiService;
 
     @GetMapping("/agent/{agentId}/performance")
     @Operation(summary = "Analizë AI e performancës së agjentit (vetëm ADMIN)")
     public ResponseEntity<AgentPerformanceResponse> analyzeAgent(
             @PathVariable Long agentId) {
-
-        String agentName = userRepo.findFullNameById(agentId)
-                .orElse("Agent #" + agentId);
-
-        long totalLeads = leadRepo.countByAssignedAgentIdAndStatus(
-                agentId, LeadStatus.DONE)
-                + leadRepo.countByAssignedAgentIdAndStatus(
-                agentId, LeadStatus.IN_PROGRESS)
-                + leadRepo.countByAssignedAgentIdAndStatus(
-                agentId, LeadStatus.NEW);
-
-        long doneLeads = leadRepo.countByAssignedAgentIdAndStatus(
-                agentId, LeadStatus.DONE);
-
-        long activeLeases = contractRepo.findByAgentIdOrderByCreatedAtDesc(
-                        agentId,
-                        org.springframework.data.domain.PageRequest.of(0, Integer.MAX_VALUE))
-                .getTotalElements();
-
-        long totalSales = saleContractRepo
-                .findByAgentIdOrderByCreatedAtDesc(
-                        agentId,
-                        org.springframework.data.domain.PageRequest.of(0, Integer.MAX_VALUE))
-                .getTotalElements();
-
-        BigDecimal revenue = paymentRepo.totalRevenue();
-
-        AgentPerformanceRequest req = new AgentPerformanceRequest(
-                agentId, agentName,
-                (int) totalLeads, (int) doneLeads,
-                (int) activeLeases, (int) totalSales,
-                revenue != null ? revenue.toPlainString() : "0"
-        );
-
-        return ok(aiService.analyzeAgentPerformance(req));
+        return ok(adminAiService.analyzeAgentPerformance(agentId));
     }
 }

--- a/src/main/java/com/realestate/backend/service/AdminAiService.java
+++ b/src/main/java/com/realestate/backend/service/AdminAiService.java
@@ -1,0 +1,64 @@
+package com.realestate.backend.service;
+
+import com.realestate.backend.dto.ai.AiDtos.*;
+import com.realestate.backend.entity.enums.LeadStatus;
+import com.realestate.backend.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAiService {
+
+    private final AiService               aiService;
+    private final UserRepository          userRepo;
+    private final LeadRequestRepository   leadRepo;
+    private final LeaseContractRepository contractRepo;
+    private final SaleContractRepository  saleContractRepo;
+    private final PaymentRepository       paymentRepo;
+
+    @Transactional(readOnly = true)
+    public AgentPerformanceResponse analyzeAgentPerformance(Long agentId) {
+
+        String agentName = userRepo.findFullNameById(agentId)
+                .orElse("Agent #" + agentId);
+
+        long totalLeads =
+                leadRepo.countByAssignedAgentIdAndStatus(agentId, LeadStatus.DONE)
+                        + leadRepo.countByAssignedAgentIdAndStatus(agentId, LeadStatus.IN_PROGRESS)
+                        + leadRepo.countByAssignedAgentIdAndStatus(agentId, LeadStatus.NEW);
+
+        long doneLeads = leadRepo.countByAssignedAgentIdAndStatus(
+                agentId, LeadStatus.DONE);
+
+        long activeLeases = contractRepo
+                .findByAgentIdOrderByCreatedAtDesc(
+                        agentId,
+                        PageRequest.of(0, Integer.MAX_VALUE))
+                .getTotalElements();
+
+        long totalSales = saleContractRepo
+                .findByAgentIdOrderByCreatedAtDesc(
+                        agentId,
+                        PageRequest.of(0, Integer.MAX_VALUE))
+                .getTotalElements();
+
+        BigDecimal revenue = paymentRepo.totalRevenue();
+
+        AgentPerformanceRequest req = new AgentPerformanceRequest(
+                agentId,
+                agentName,
+                (int) totalLeads,
+                (int) doneLeads,
+                (int) activeLeases,
+                (int) totalSales,
+                revenue != null ? revenue.toPlainString() : "0"
+        );
+
+        return aiService.analyzeAgentPerformance(req);
+    }
+}


### PR DESCRIPTION
## Çfarë u Ndryshua
Logjika e biznesit u transferua nga AdminAiController 
në një shtresë të dedikuar AdminAiService.

## Para
AdminAiController injektonte 5 repository + AiService 
dhe ndërtonte vetë AgentPerformanceRequest brenda kontrollerit.

## Pas
AdminAiController injekton vetëm AdminAiService (1 varësi).
AdminAiService mban të gjithë logjikën dhe thërret AiService.

## Skedarët
| Skedar | Aksion |
|--------|--------|
| AdminAiService.java | E re |
| AdminAiController.java | Refaktoruar |
| AiController.java | E paprekur |
| AiService.java | E paprekur |

Closes #115 