### PR TITLE
Send tenant-specific scheduler notifications

### DIFF
--- a/src/main/java/com/realestate/backend/service/SchedulerService.java
+++ b/src/main/java/com/realestate/backend/service/SchedulerService.java
@@ -1,6 +1,9 @@
 package com.realestate.backend.service;
 
+import com.realestate.backend.entity.enums.LeadStatus;
+import com.realestate.backend.entity.enums.NotificationType;
 import com.realestate.backend.repository.LeadRequestRepository;
+import com.realestate.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -18,19 +21,33 @@ public class SchedulerService {
     private final LeaseContractService     leaseContractService;
     private final SchemaRegistryRepository schemaRegistryRepo;
     private final LeadRequestRepository leadRequestRepository;
+    private final NotificationService      notificationService;
+    private final UserRepository userRepository;
 
     @Scheduled(cron = "0 0 0 * * *")
     public void markOverduePayments() {
         var schemas = activeSchemas();
-        int totalMarked = 0;
 
         for (var schema : schemas) {
             try {
                 TenantContext.set(null, null, schema.getSchemaName(), "SYSTEM");
                 int count = paymentService.markOverduePayments();
-                totalMarked += count;
+
+                if (count > 0) {
+                    notifyTenantAdmins(
+                            schema.getTenant().getId(),
+                            schema.getSchemaName(),
+                            "⏰ Overdue Payments Detected",
+                            count + " payment(s) marked as overdue. Review required.",
+                            NotificationType.WARNING,
+                            "payment", null,
+                            "/admin/payments"
+                    );
+                }
+
                 log.info("[Scheduler] Schema={} — {} payments marked OVERDUE",
                         schema.getSchemaName(), count);
+
             } catch (Exception e) {
                 log.error("[Scheduler] Error for schema={}: {}",
                         schema.getSchemaName(), e.getMessage());
@@ -38,7 +55,6 @@ public class SchedulerService {
                 TenantContext.clear();
             }
         }
-        log.info("[Scheduler] Total overdue marked: {}", totalMarked);
     }
 
     @Scheduled(cron = "0 0 8 * * *")
@@ -47,10 +63,22 @@ public class SchedulerService {
             try {
                 TenantContext.set(null, null, schema.getSchemaName(), "SYSTEM");
                 var expiring = leaseContractService.getExpiringSoon();
+
+
                 if (!expiring.isEmpty()) {
-                    log.warn("[Scheduler] Schema={} — {} contracts expiring in 30 days",
+                    notifyTenantAdmins(
+                            schema.getTenant().getId(),
+                            schema.getSchemaName(),
+                            "📋 Contracts Expiring Soon",
+                            expiring.size() + " lease contract(s) expire within 30 days.",
+                            NotificationType.REMINDER,
+                            "lease_contract", null,
+                            "/admin/contracts"
+                    );
+                    log.warn("[Scheduler] Schema={} — {} contracts expiring",
                             schema.getSchemaName(), expiring.size());
                 }
+
             } catch (Exception e) {
                 log.error("[Scheduler] Error for schema={}: {}",
                         schema.getSchemaName(), e.getMessage());
@@ -59,6 +87,7 @@ public class SchedulerService {
             }
         }
     }
+
 
     @Scheduled(fixedDelay = 21600000)
     public void logSystemStats() {
@@ -88,7 +117,29 @@ public class SchedulerService {
         for (var schema : activeSchemas()) {
             try {
                 TenantContext.set(null, null, schema.getSchemaName(), "SYSTEM");
-                generateWeeklyReport(schema.getSchemaName());
+
+                int  overdueCount    = paymentService.markOverduePayments();
+                var  expiring        = leaseContractService.getExpiringSoon();
+                long unassignedLeads = leadRequestRepository.countByStatus(LeadStatus.NEW);
+
+
+                String msg = String.format(
+                        "Weekly Report: %d overdue payments · %d expiring contracts · %d unassigned leads",
+                        overdueCount, expiring.size(), unassignedLeads
+                );
+
+                notifyTenantAdmins(
+                        schema.getTenant().getId(),
+                        schema.getSchemaName(),
+                        "📊 Weekly System Report",
+                        msg,
+                        NotificationType.INFO,
+                        null, null,
+                        "/admin/background-jobs"
+                );
+
+                log.info("[WeeklyReport] Schema={} — {}", schema.getSchemaName(), msg);
+
             } catch (Exception e) {
                 log.error("[WeeklyReport] Error for schema={}: {}",
                         schema.getSchemaName(), e.getMessage());
@@ -98,6 +149,28 @@ public class SchedulerService {
         }
     }
     // ── Helper ─────────────────────────────────────────────────
+    private void notifyTenantAdmins(Long tenantId,
+                                    String schemaName,
+                                    String title, String message,
+                                    NotificationType type,
+                                    String entityType, Long entityId,
+                                    String actionUrl) {
+        try {
+            userRepository.findAllByTenantId(tenantId).stream() //
+                    .filter(u -> u.getRole().name().equals("ADMIN"))
+                    .filter(u -> Boolean.TRUE.equals(u.getIsActive()))
+                    .filter(u -> u.getDeletedAt() == null)
+                    .forEach(admin ->
+                            notificationService.sendNotification(
+                                    admin.getId(), title, message,
+                                    type, entityType, entityId, actionUrl
+                            )
+                    );
+        } catch (Exception e) {
+            log.error("[Scheduler] Failed to notify admins for schema={}: {}",
+                    schemaName, e.getMessage());
+        }
+    }
     private java.util.List<com.realestate.backend.entity.tenant.TenantSchemaRegistry> activeSchemas() {
         return schemaRegistryRepo.findAll()
                 .stream()


### PR DESCRIPTION
Ky PR shton logjikën që SchedulerService të krijojë njoftime për admin-at kur job-et automatike prodhojnë rezultate, si pagesa të vonuara, kontrata që skadojnë së shpejti dhe raporti javor. Gjithashtu, njoftimet dërgohen vetëm te admin-at e tenant-it përkatës përmes tenantId, duke shmangur përzierjen mes tenant-ëve.

Closes #117 